### PR TITLE
Replace local @spree/sdk with NPM package and switch to Turbopack

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@spree/sdk"],
   images: {
     qualities: [25, 50, 75, 100],
     dangerouslyAllowLocalIP: true, // Allow localhost images in development

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nextjs-starter-spree",
       "version": "0.1.0",
       "dependencies": {
-        "@spree/sdk": "file:../spree/sdk",
+        "@spree/sdk": "^0.1.4",
         "next": "^16",
         "react": "^19",
         "react-dom": "^19"
@@ -27,28 +27,6 @@
       "name": "@spree/sdk",
       "version": "0.1.0",
       "extraneous": true,
-      "license": "BSD-3-Clause",
-      "devDependencies": {
-        "@types/node": "^20.0.0",
-        "tsup": "^8.0.0",
-        "tsx": "^4.0.0",
-        "typescript": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.7.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "../spree/sdk": {
-      "name": "@spree/sdk",
-      "version": "0.1.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -552,8 +530,21 @@
       }
     },
     "node_modules/@spree/sdk": {
-      "resolved": "../spree/sdk",
-      "link": true
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@spree/sdk/-/sdk-0.1.4.tgz",
+      "integrity": "sha512-Uf8MUksMUlpTpKkOGrYE/P+V/TAc/un+cVzYhgm7RLF+f0EHgyFyoeeIOT8Uc7Vs0TLhdiHKvsh8VceLFG/Z4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -1819,7 +1810,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3001 --webpack",
-    "build": "next build --webpack",
+    "dev": "next dev -p 3001 --turbopack",
+    "build": "next build",
     "start": "next start -p 3001",
     "lint": "biome lint .",
     "format": "biome format . --write",
     "check": "biome check ."
   },
   "dependencies": {
-    "@spree/sdk": "file:../spree/sdk",
+    "@spree/sdk": "^0.1.4",
     "next": "^16",
     "react": "^19",
     "react-dom": "^19"

--- a/src/app/[country]/[locale]/(storefront)/account/layout.tsx
+++ b/src/app/[country]/[locale]/(storefront)/account/layout.tsx
@@ -146,7 +146,11 @@ interface AccountShellProps {
   children: React.ReactNode;
   basePath: string;
   pathname: string;
-  user?: { first_name?: string; last_name?: string; email?: string } | null;
+  user?: {
+    first_name?: string | null;
+    last_name?: string | null;
+    email?: string;
+  } | null;
   onLogout?: () => void;
   isLoading?: boolean;
 }


### PR DESCRIPTION
- Change @spree/sdk from file:../spree/sdk to ^0.1.4 from NPM
- Switch dev script from --webpack to --turbopack
- Remove --webpack from build script (Turbopack is default)
- Remove transpilePackages from next.config.ts
- Fix AccountShellProps types to match NPM SDK User type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Build system updated to use faster bundling technology.

* **Bug Fixes**
  * Account page now properly handles cases where user names are not available.

* **Chores**
  * SDK dependency updated to a published version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->