### PR TITLE
Fix guest checkout 'Order not found' on order-placed page

### DIFF
--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -116,9 +116,17 @@ export function CartProvider({ children }: { children: ReactNode }) {
   );
 
   // Re-fetch cart on navigation (e.g., after checkout completes, the stale
-  // cart token will be cleared by getCart and the cart state will update)
-  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname triggers re-fetch on navigation
+  // cart token will be cleared by getCart and the cart state will update).
+  // On the order-placed page, skip refreshCart to avoid a race condition:
+  // getCart() auto-clears the cart token cookie on error (completed order
+  // is no longer a cart), which removes the only auth token guest users
+  // have before getCheckoutOrder() can use it.
   useEffect(() => {
+    if (pathname.includes("/order-placed/")) {
+      setCart(null);
+      setLoading(false);
+      return;
+    }
     refreshCart();
   }, [refreshCart, pathname]);
 


### PR DESCRIPTION
## Problem
Guest checkout was showing "Order not found" on the order-placed page due to a race condition where `getCart()` cleared the cart token cookie before `getCheckoutOrder()` could use it for authentication.

## Solution
Skip the `refreshCart()` call when navigating to the order-placed page. Instead, directly clear the cart state to prevent the race condition while still maintaining proper state cleanup.

## Changes
- Add pathname check in the `useEffect` hook to detect order-placed page navigation
- Clear cart state directly without calling `refreshCart()` on order-placed pages
- Updated comments to explain the race condition and solution