### PR TITLE
Bump packages to add supoort for cart/order/line items metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@next/third-parties": "^16.1.6",
         "@sentry/nextjs": "^10.38.0",
-        "@spree/next": "^0.5.0",
-        "@spree/sdk": "^0.5.0",
+        "@spree/next": "^0.6.0",
+        "@spree/sdk": "^0.6.0",
         "@stripe/react-stripe-js": "^5.6.0",
         "@stripe/stripe-js": "^8.7.0",
         "next": "^16",
@@ -4729,20 +4729,20 @@
       }
     },
     "node_modules/@spree/next": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@spree/next/-/next-0.5.0.tgz",
-      "integrity": "sha512-62PCRtupuveus1fttYtzs9bsXQ0STDnbQQ9ArThEttnG6grJbnkWUVtLS6GVzvEhImb32gndjfk22pOs6b2TBA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@spree/next/-/next-0.6.0.tgz",
+      "integrity": "sha512-sSzjTtaevScLXeHlT7Gq0Z+ppmW2RbXPyNQBcY+/UQVuAs0/FWk4FgYaWQhd6DFG8Ne4GXtIKAF2zZewSe3zww==",
       "license": "MIT",
       "peerDependencies": {
-        "@spree/sdk": ">=0.5.0",
+        "@spree/sdk": ">=0.6.0",
         "next": ">=15.0.0",
         "react": ">=19.0.0"
       }
     },
     "node_modules/@spree/sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@spree/sdk/-/sdk-0.5.0.tgz",
-      "integrity": "sha512-49PR/S/fNKbpZJeinS3dRdO1DlZYa2dukanB/nNkryn5/slNcKZaVBGbDcgv9LvZUJofDwV95pFzUDChnjOqiQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@spree/sdk/-/sdk-0.6.0.tgz",
+      "integrity": "sha512-BSBvxpb2UiupCgOPtVQ9zOc2TjixlzK5ICPHFEiu/1rjfwMtM1YwG4roGLPNNI+eUEnwNjJ8ImMd6jumtEJwRg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "dependencies": {
     "@next/third-parties": "^16.1.6",
     "@sentry/nextjs": "^10.38.0",
-    "@spree/next": "^0.5.0",
-    "@spree/sdk": "^0.5.0",
+    "@spree/next": "^0.6.0",
+    "@spree/sdk": "^0.6.0",
     "@stripe/react-stripe-js": "^5.6.0",
     "@stripe/stripe-js": "^8.7.0",
     "next": "^16",

--- a/src/contexts/StoreContext.tsx
+++ b/src/contexts/StoreContext.tsx
@@ -61,8 +61,8 @@ function resolveCountryAndCurrency(
   if (country) {
     return {
       country,
-      currency: country.currency || storeData.default_currency || "USD",
-      locale: country.default_locale || storeData.default_locale || "en",
+      currency: country.currency || "USD",
+      locale: country.default_locale || "en",
       needsRedirect: false,
     };
   }
@@ -72,16 +72,16 @@ function resolveCountryAndCurrency(
   if (defaultCountry) {
     return {
       country: defaultCountry,
-      currency: defaultCountry.currency || storeData.default_currency || "USD",
-      locale: defaultCountry.default_locale || storeData.default_locale || "en",
+      currency: defaultCountry.currency || "USD",
+      locale: defaultCountry.default_locale || "en",
       needsRedirect: true,
     };
   }
 
   return {
     country: undefined,
-    currency: storeData.default_currency || "USD",
-    locale: storeData.default_locale || "en",
+    currency: "USD",
+    locale: "en",
     needsRedirect: false,
   };
 }

--- a/src/lib/data/__tests__/cart.test.ts
+++ b/src/lib/data/__tests__/cart.test.ts
@@ -111,7 +111,7 @@ describe("cart server actions", () => {
 
       const result = await updateCartItem("li-1", 3);
 
-      expect(mockUpdateItem).toHaveBeenCalledWith("li-1", 3);
+      expect(mockUpdateItem).toHaveBeenCalledWith("li-1", { quantity: 3 });
       expect(result).toEqual({ success: true, cart: mockCart });
     });
 

--- a/src/lib/data/cart.ts
+++ b/src/lib/data/cart.ts
@@ -35,7 +35,7 @@ export async function addToCart(variantId: string, quantity: number) {
 
 export async function updateCartItem(lineItemId: string, quantity: number) {
   return actionResult(async () => {
-    const cart = await updateItem(lineItemId, quantity);
+    const cart = await updateItem(lineItemId, { quantity });
     return { cart };
   }, "Failed to update cart item");
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated @spree/next and @spree/sdk dependencies to version 0.6.0

* **Bug Fixes**
  * Improved default currency and locale handling with consistent fallback values (USD and English)
  * Fixed cart item update functionality to properly handle quantity modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->