### PR TITLE
Added root: `__dirname` to the turbopack config in `next.config.ts`.

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const nextConfig: NextConfig = {
   },
   transpilePackages: ["@spree/next", "@spree/sdk"],
   turbopack: {
+    root: __dirname,
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],


### PR DESCRIPTION
This tells Next.js that the storefront directory is the project root,
 so it won't get confused by parent lockfiles when running inside the apps/storefront/ structure from create-spree-app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve tooling setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->