### PR TITLE
Fixed 404 on Category pages

### DIFF
--- a/src/app/[country]/[locale]/(storefront)/c/[...permalink]/page.tsx
+++ b/src/app/[country]/[locale]/(storefront)/c/[...permalink]/page.tsx
@@ -53,7 +53,11 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
 
       <div
         className="flex flex-col justify-end min-h-[350px] bg-gray-50 bg-cover bg-center"
-        style={{ backgroundImage: `url(${category.image_url})` }}
+        style={
+          category.image_url
+            ? { backgroundImage: `url(${category.image_url})` }
+            : undefined
+        }
       >
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <Breadcrumbs


### PR DESCRIPTION
When category.image_url is null (as it is for the Blenders category in the Spree API), the rendered HTML becomes:

```typescript
  style="background-image: url(null)"
```

  The browser treats url(null) as a relative URL literally named null, which resolves against the current page URL. So on /us/en/c/kitchen/blenders, the browser fires off GET
  /us/en/c/kitchen/null. Next.js routes that through the same [...permalink] catch-all, getCategory("kitchen/null") returns 404 → SpreeError: Category not found. The AbortError is the
  browser cancelling the same phantom request when the dev page hot-reloads.

  Fix

  Only set backgroundImage when category.image_url is truthy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed category pages to properly handle cases where no category image is available, preventing invalid background image styling from being applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->