### PR TITLE
Don't flash filter bar on PLP sort change

### DIFF
--- a/src/components/products/ProductListing.tsx
+++ b/src/components/products/ProductListing.tsx
@@ -15,7 +15,6 @@ import { PRODUCT_CARD_FIELDS } from "@/lib/data/cached";
 import {
   type ListingSearchParams,
   listingKey,
-  listingStructureKey,
 } from "@/lib/utils/listing-search-params";
 import {
   buildProductQueryParams,
@@ -56,25 +55,26 @@ interface ProductListingProps {
  * breadcrumbs, banner) can stream immediately.
  *
  * Filter / sort / query state lives in the URL via ListingSearchParams.
- * Click handlers in the filter bar write to the URL with router.push,
- * which triggers a soft navigation and re-runs this server component.
+ * Click handlers in the filter bar write to the URL with router.push
+ * inside a startTransition, which triggers a soft navigation and
+ * re-runs this server component.
  *
- * Pagination uses infinite scroll: the server renders page 1, and the
- * client InfiniteProductList island fetches subsequent pages via the
- * same server action on scroll. Filter changes unmount the island (via
- * the Suspense boundary key) so accumulated state resets cleanly.
+ * The Suspense boundary is intentionally NOT keyed on listing state.
+ * On first load the fallback shows the skeleton, but on subsequent
+ * filter / sort / query changes useTransition keeps the previous tree
+ * visible while the new server render resolves — the filter bar and
+ * grid then swap atomically, without flashing a skeleton in between.
+ *
+ * Pagination uses infinite scroll: the server renders page 1, and
+ * the client InfiniteProductList island fetches subsequent pages via
+ * the same server action on scroll. The island is keyed on the full
+ * listing state so every filter / sort / query change remounts it
+ * with the new server-provided page 1, atomically replacing the old
+ * grid without any loading fallback being shown.
  */
 export function ProductListing(props: ProductListingProps): ReactElement {
-  // Key on listingStructureKey — NOT listingKey — so sort changes
-  // don't remount the filter bar and flash the skeleton. Sort-only
-  // changes re-run the server component in place, and the filter bar
-  // keeps rendering its previous facet data until the re-render
-  // resolves (the grid swaps in via the transition pending state).
   return (
-    <Suspense
-      key={listingStructureKey(props.state)}
-      fallback={<ProductListingSkeleton />}
-    >
+    <Suspense fallback={<ProductListingSkeleton />}>
       <ProductListingInner {...props} />
     </Suspense>
   );
@@ -153,6 +153,14 @@ async function ProductListingInner({
       {hasResults ? (
         <>
           <InfiniteProductList
+            // Remount on any filter / sort / query change so the
+            // island picks up the new initialProducts and resets its
+            // accumulated scroll state. The swap is atomic — because
+            // the surrounding Suspense boundary isn't keyed and the
+            // new instance mounts with products already populated,
+            // the user sees the grid update in place with no loading
+            // fallback shown.
+            key={listingKey(state)}
             initialProducts={products}
             initialPage={1}
             totalPages={totalPages}

--- a/src/components/products/ProductListing.tsx
+++ b/src/components/products/ProductListing.tsx
@@ -15,6 +15,7 @@ import { PRODUCT_CARD_FIELDS } from "@/lib/data/cached";
 import {
   type ListingSearchParams,
   listingKey,
+  listingStructureKey,
 } from "@/lib/utils/listing-search-params";
 import {
   buildProductQueryParams,
@@ -64,9 +65,14 @@ interface ProductListingProps {
  * the Suspense boundary key) so accumulated state resets cleanly.
  */
 export function ProductListing(props: ProductListingProps): ReactElement {
+  // Key on listingStructureKey — NOT listingKey — so sort changes
+  // don't remount the filter bar and flash the skeleton. Sort-only
+  // changes re-run the server component in place, and the filter bar
+  // keeps rendering its previous facet data until the re-render
+  // resolves (the grid swaps in via the transition pending state).
   return (
     <Suspense
-      key={listingKey(props.state)}
+      key={listingStructureKey(props.state)}
       fallback={<ProductListingSkeleton />}
     >
       <ProductListingInner {...props} />
@@ -106,10 +112,14 @@ async function ProductListingInner({
     fields: PRODUCT_CARD_FIELDS,
   };
 
-  // Filters fetch: Ransack-wrapped with the same active filter context,
-  // so facet counts reflect the user's current selection.
+  // Filters fetch: Ransack-wrapped with the same active filter
+  // context, so facet counts reflect the user's current selection.
+  // Sort is stripped because facet counts are independent of sort
+  // order — keeping it in the args would bust the cache on every
+  // sort change for no functional reason.
+  const { sort: _sort, ...filterQueryParams } = queryParams;
   const filterFetchParams = wrapInRansackParams({
-    ...queryParams,
+    ...filterQueryParams,
     ...baseParams,
   });
 

--- a/src/lib/utils/listing-search-params.ts
+++ b/src/lib/utils/listing-search-params.ts
@@ -142,18 +142,35 @@ export function buildListingSearchParams(
 }
 
 /**
- * Serialize listing params into a stable key string. Used for analytics
- * dedup and as the Suspense boundary key — not for the Next cache, which
- * keys on function arguments automatically.
+ * Serialize full listing state into a stable key string, INCLUDING
+ * sortBy. Used for analytics dedup where "same filters, different
+ * sort" counts as a distinct list view.
  *
  * Uses JSON.stringify rather than a delimiter-joined string so that
  * values containing special characters (e.g. a search query with a
- * pipe) can't produce colliding keys for different filter states.
+ * pipe) can't produce colliding keys for different states.
  */
 export function listingKey(state: ListingSearchParams): string {
   return JSON.stringify({
     q: state.query ?? "",
     s: state.filters.sortBy ?? "",
+    pMin: state.filters.priceMin ?? "",
+    pMax: state.filters.priceMax ?? "",
+    a: state.filters.availability ?? "",
+    o: [...state.filters.optionValues].sort(),
+  });
+}
+
+/**
+ * Serialize listing state EXCLUDING sortBy. Used as the Suspense
+ * boundary key on PLPs so sort changes don't unmount the filter bar
+ * and flash the skeleton — only filter / query changes do. Facet
+ * counts are independent of sort order, so the filter bar can keep
+ * rendering its previous data while the grid re-fetches in-place.
+ */
+export function listingStructureKey(state: ListingSearchParams): string {
+  return JSON.stringify({
+    q: state.query ?? "",
     pMin: state.filters.priceMin ?? "",
     pMax: state.filters.priceMax ?? "",
     a: state.filters.availability ?? "",

--- a/src/lib/utils/listing-search-params.ts
+++ b/src/lib/utils/listing-search-params.ts
@@ -142,35 +142,20 @@ export function buildListingSearchParams(
 }
 
 /**
- * Serialize full listing state into a stable key string, INCLUDING
- * sortBy. Used for analytics dedup where "same filters, different
- * sort" counts as a distinct list view.
+ * Serialize the full listing state into a stable key string. Used as
+ * the React key on InfiniteProductList (so every filter / sort / query
+ * change remounts the island with fresh server-provided page 1 data)
+ * and as the stateKey on ListingAnalytics (so each distinct listing
+ * state fires a view_item_list event exactly once).
  *
- * Uses JSON.stringify rather than a delimiter-joined string so that
- * values containing special characters (e.g. a search query with a
- * pipe) can't produce colliding keys for different states.
+ * Uses JSON.stringify rather than a delimiter-joined string so values
+ * containing special characters (e.g. a search query with a pipe)
+ * can't produce colliding keys for different states.
  */
 export function listingKey(state: ListingSearchParams): string {
   return JSON.stringify({
     q: state.query ?? "",
     s: state.filters.sortBy ?? "",
-    pMin: state.filters.priceMin ?? "",
-    pMax: state.filters.priceMax ?? "",
-    a: state.filters.availability ?? "",
-    o: [...state.filters.optionValues].sort(),
-  });
-}
-
-/**
- * Serialize listing state EXCLUDING sortBy. Used as the Suspense
- * boundary key on PLPs so sort changes don't unmount the filter bar
- * and flash the skeleton — only filter / query changes do. Facet
- * counts are independent of sort order, so the filter bar can keep
- * rendering its previous data while the grid re-fetches in-place.
- */
-export function listingStructureKey(state: ListingSearchParams): string {
-  return JSON.stringify({
-    q: state.query ?? "",
     pMin: state.filters.priceMin ?? "",
     pMax: state.filters.priceMax ?? "",
     a: state.filters.availability ?? "",


### PR DESCRIPTION
Sort changes on the product listing used to unmount the filter bar and re-render its skeleton, even though facet counts are unchanged and the filter bar itself doesn't depend on sort order. Two things caused this:

1. The Suspense boundary was keyed on listingKey(state), which includes sortBy. Re-keying a Suspense boundary unmounts its children, so every sort click flashed through the loading state.

2. The facet fetch was passed sortBy via buildProductQueryParams, so the cached filters response was keyed per sort order for no functional reason (facets are sort-independent). That also caused the facet fetch to re-execute on every sort change.

Fix:

- Introduce listingStructureKey() that serializes listing state EXCLUDING sortBy. Use it as the Suspense boundary key. listingKey() stays as-is (still includes sortBy) for analytics dedup, where "same list, new sort" is legitimately a distinct view event.

- Strip sort from filterFetchParams before the facet fetch, so sort changes hit the same cached filters entry.

Net effect: sort change → server component re-renders in place, products fetch runs with the new sort key, facets hit the cache, filter bar keeps rendering previous data under aria-busy, grid swaps in once the transition resolves. No more skeleton flash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stopping unexpected UI resets when changing filters/sort so the filter bar and previous results aren’t lost.
  * Preventing sort changes from affecting facet/cache behavior so filter counts stay stable.
  * Ensuring listings replace page 1 atomically and reset pagination when the full listing state changes without showing a loading fallback.

* **Documentation**
  * Clarified comments describing how listing state keys trigger remounts and analytics events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->