### PR TITLE
Upgrade @spree/sdk to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@next/third-parties": "^16.1.6",
         "@paypal/react-paypal-js": "^9.1.1",
         "@sentry/nextjs": "^10.38.0",
-        "@spree/sdk": "^1.0.0",
+        "@spree/sdk": "^1.1.0",
         "@stripe/react-stripe-js": "^5.6.0",
         "@stripe/stripe-js": "^8.7.0",
         "@swc/helpers": "^0.5.21",
@@ -5689,9 +5689,9 @@
       }
     },
     "node_modules/@spree/sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@spree/sdk/-/sdk-1.0.1.tgz",
-      "integrity": "sha512-Nywp5m0VZQRHJC5UIKkMBZgf4+9LPUteCaQCNKJ63mdSjpTi15IwuyCVFU/F1nikV9YBraWNoMoQkY6AKDWqdQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@spree/sdk/-/sdk-1.1.0.tgz",
+      "integrity": "sha512-xPLoi4FzwH4VnuoJs4xePfynq0SF1Cth0oRbAYzoqC80adKd3ZG0jGzlGNuYnjO7zYrYW7Y4YHwHkJoo0iVr/w==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@next/third-parties": "^16.1.6",
     "@paypal/react-paypal-js": "^9.1.1",
     "@sentry/nextjs": "^10.38.0",
-    "@spree/sdk": "^1.0.0",
+    "@spree/sdk": "^1.1.0",
     "@stripe/react-stripe-js": "^5.6.0",
     "@stripe/stripe-js": "^8.7.0",
     "@swc/helpers": "^0.5.21",

--- a/src/components/products/ProductCustomFields.tsx
+++ b/src/components/products/ProductCustomFields.tsx
@@ -25,7 +25,11 @@ function renderValue(
         : JSON.stringify(field.value);
     case "rich_text":
       // Value is admin-authored HTML from the Spree CMS backend (trusted source)
-      return <span dangerouslySetInnerHTML={{ __html: field.value }} />;
+      return <span dangerouslySetInnerHTML={{ __html: field.value ?? "" }} />;
+    case "short_text":
+    case "long_text":
+    case "number":
+      return String(field.value);
     default:
       return String(field.value);
   }

--- a/src/components/products/ProductCustomFields.tsx
+++ b/src/components/products/ProductCustomFields.tsx
@@ -5,10 +5,6 @@ interface ProductCustomFieldsProps {
   customFields?: Array<CustomField>;
 }
 
-function normalizeType(type: string): string {
-  return type.split("::").pop() || type;
-}
-
 function renderBooleanValue(
   value: unknown,
   t: ReturnType<typeof useTranslations<"products">>,
@@ -18,17 +14,16 @@ function renderBooleanValue(
 
 function renderValue(
   field: CustomField,
-  normalizedType: string,
   t: ReturnType<typeof useTranslations<"products">>,
 ): React.ReactNode {
-  switch (normalizedType) {
-    case "Boolean":
+  switch (field.field_type) {
+    case "boolean":
       return renderBooleanValue(field.value, t);
-    case "Json":
+    case "json":
       return typeof field.value === "string"
         ? field.value
         : JSON.stringify(field.value);
-    case "RichText":
+    case "rich_text":
       // Value is admin-authored HTML from the Spree CMS backend (trusted source)
       return <span dangerouslySetInnerHTML={{ __html: field.value }} />;
     default:
@@ -51,19 +46,16 @@ export function ProductCustomFields({
         {t("properties")}
       </h2>
       <dl className="space-y-3">
-        {customFields.map((field) => {
-          const type = normalizeType(field.type);
-          return (
-            <div key={field.id} className="flex">
-              <dt className="w-32 shrink-0 text-gray-500 text-sm">
-                {field.label}
-              </dt>
-              <dd className="text-gray-900 text-sm min-w-0">
-                {renderValue(field, type, t)}
-              </dd>
-            </div>
-          );
-        })}
+        {customFields.map((field) => (
+          <div key={field.id} className="flex">
+            <dt className="w-32 shrink-0 text-gray-500 text-sm">
+              {field.label}
+            </dt>
+            <dd className="text-gray-900 text-sm min-w-0">
+              {renderValue(field, t)}
+            </dd>
+          </div>
+        ))}
       </dl>
     </div>
   );

--- a/src/lib/metadata/product.ts
+++ b/src/lib/metadata/product.ts
@@ -21,7 +21,7 @@ export async function generateProductMetadata({
     return { title: "Product Not Found" };
   }
 
-  const title = product.name;
+  const title = product.meta_title || product.name;
   const description = product.meta_description
     ? product.meta_description
     : product.description


### PR DESCRIPTION
## Summary

- Bump `@spree/sdk` from `^1.0.0` to `^1.1.0` (resolves to 1.1.0).
- Migrate `ProductCustomFields` from the deprecated `CustomField.type` (Ruby STI class name) to the new `field_type` token (`boolean`, `json`, `rich_text`, etc.).
- Use `product.meta_title` for product page SEO metadata, falling back to `product.name` when unset — matching the existing category metadata pattern.

## Test plan

- [ ] Confirm product pages render custom fields correctly (boolean, JSON, rich text, plain text).
- [ ] Verify product page `<title>` and Open Graph title use `meta_title` when set in Spree admin.
- [ ] Verify product pages without `meta_title` still use the product name.
- [ ] Run `npm run check` and `npx tsc --noEmit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK dependency to version 1.1.0

* **Improvements**
  * Enhanced custom product field rendering for better display accuracy and consistency
  * Improved product page titles to prioritize custom meta titles for better SEO control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->