### PR TITLE
V-3499 Implement session sync with JWT refresh on tab focus

### DIFF
--- a/src/components/checkout/AddressSection.tsx
+++ b/src/components/checkout/AddressSection.tsx
@@ -95,7 +95,7 @@ export function AddressSection({
       ? initialSavedAddresses[0]
       : undefined;
 
-  const [email, setEmail] = useState(cart.email || "");
+  const [email, setEmail] = useState(cart.email || user?.email || "");
   const defaultCountryIso = countries[0]?.iso ?? "";
 
   const [shipAddress, setShipAddress] = useState<AddressFormData>(() => {
@@ -274,10 +274,13 @@ export function AddressSection({
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           onBlur={handleEmailBlur}
-          disabled={isAuthenticated}
+          // Lock to the account email only when we actually have one — never
+          // leave the field both disabled and blank (a stale session would
+          // otherwise make checkout impossible).
+          disabled={isAuthenticated && !!email}
           placeholder={t("emailAddress")}
         />
-        {isAuthenticated && (
+        {isAuthenticated && !!email && (
           <p className="text-xs text-gray-500 mt-1.5">
             {t("usingAccountEmail")}
           </p>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -76,13 +77,37 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, [router]);
 
+  // Timestamp of the last session sync, used to throttle focus-driven re-syncs.
+  const lastSyncRef = useRef(0);
+
   // Initialize auth state
   useEffect(() => {
     const initAuth = async () => {
+      lastSyncRef.current = Date.now();
       await refreshUser();
       setLoading(false);
     };
     initAuth();
+  }, [refreshUser]);
+
+  // Re-sync the session when the tab regains focus after being idle. The JWT
+  // can expire while the tab is backgrounded; refreshing on return renews it
+  // (or treats the session as logged out) without a manual reload. Throttled
+  // so ordinary focus churn doesn't hit the server on every event.
+  useEffect(() => {
+    const RESYNC_THROTTLE_MS = 30_000;
+    const maybeResync = () => {
+      if (document.visibilityState !== "visible") return;
+      if (Date.now() - lastSyncRef.current < RESYNC_THROTTLE_MS) return;
+      lastSyncRef.current = Date.now();
+      void refreshUser();
+    };
+    document.addEventListener("visibilitychange", maybeResync);
+    window.addEventListener("focus", maybeResync);
+    return () => {
+      document.removeEventListener("visibilitychange", maybeResync);
+      window.removeEventListener("focus", maybeResync);
+    };
   }, [refreshUser]);
 
   // Login

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -11,10 +11,10 @@ import {
   useState,
 } from "react";
 import {
-  getCustomer,
   login as loginAction,
   logout as logoutAction,
   register as registerAction,
+  syncSession,
 } from "@/lib/data/customer";
 
 export interface User {
@@ -59,15 +59,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const router = useRouter();
 
-  // Fetch current user from server
+  // Fetch current user from server, refreshing an expired JWT when possible.
+  // A transparent refresh persists a new token via a Server Action (cookie
+  // writes aren't allowed during a Server Component render), so re-render the
+  // server components afterwards to replace any data they fetched with the
+  // stale session.
   const refreshUser = useCallback(async () => {
     try {
-      const customer = await getCustomer();
+      const { customer, refreshed } = await syncSession();
       setUser(customer ? toUser(customer) : null);
+      if (refreshed) {
+        router.refresh();
+      }
     } catch {
       setUser(null);
     }
-  }, []);
+  }, [router]);
 
   // Initialize auth state
   useEffect(() => {

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,102 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// useRouter must return a stable reference (as it does in Next), otherwise
+// refreshUser's [router] dependency changes every render and the sync effects
+// loop forever.
+const { mockRefresh, mockRouter } = vi.hoisted(() => {
+  const refresh = vi.fn();
+  return {
+    mockRefresh: refresh,
+    mockRouter: { refresh, push: () => {}, replace: () => {} },
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+}));
+
+vi.mock("@/lib/data/customer", () => ({
+  syncSession: vi.fn(),
+  login: vi.fn(),
+  logout: vi.fn(),
+  register: vi.fn(),
+}));
+
+import { AuthProvider, useAuth } from "@/contexts/AuthContext";
+import { syncSession } from "@/lib/data/customer";
+
+const mockSyncSession = vi.mocked(syncSession);
+
+const mockCustomer = {
+  id: "user-1",
+  email: "test@example.com",
+  first_name: "Test",
+  last_name: "User",
+} as never;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+/** Dispatch a visibility change while pretending `msAhead` has elapsed. */
+async function returnToTab(msAhead: number) {
+  const spy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + msAhead);
+  await act(async () => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  spy.mockRestore();
+}
+
+describe("AuthContext session sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSyncSession.mockResolvedValue({
+      customer: mockCustomer,
+      refreshed: false,
+    });
+  });
+
+  it("syncs the session on mount and exposes the customer", async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockSyncSession).toHaveBeenCalledTimes(1);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user?.email).toBe("test@example.com");
+  });
+
+  it("re-syncs when the tab regains focus, throttling rapid events", async () => {
+    renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(mockSyncSession).toHaveBeenCalledTimes(1));
+
+    // Within the throttle window — ignored.
+    await returnToTab(5_000);
+    expect(mockSyncSession).toHaveBeenCalledTimes(1);
+
+    // Past the throttle window — re-syncs.
+    await returnToTab(31_000);
+    await waitFor(() => expect(mockSyncSession).toHaveBeenCalledTimes(2));
+  });
+
+  it("re-renders server components after a transparent refresh", async () => {
+    mockSyncSession.mockResolvedValue({
+      customer: mockCustomer,
+      refreshed: true,
+    });
+
+    renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalledTimes(1));
+  });
+
+  it("clears the user when the session is gone", async () => {
+    mockSyncSession.mockResolvedValue({ customer: null, refreshed: false });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+});

--- a/src/lib/data/__tests__/customer.test.ts
+++ b/src/lib/data/__tests__/customer.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/lib/spree", () => ({
       return fn({ token: "jwt-token" });
     },
   ),
+  ensureFreshSession: vi.fn().mockResolvedValue("valid"),
   getAccessToken: vi.fn().mockResolvedValue("jwt-token"),
   setAccessToken: vi.fn(),
   clearAccessToken: vi.fn(),
@@ -59,6 +60,7 @@ import {
   login,
   logout,
   register,
+  syncSession,
   updateCustomer,
 } from "@/lib/data/customer";
 
@@ -120,6 +122,56 @@ describe("customer server actions", () => {
       );
       expect(clearAccessToken).not.toHaveBeenCalled();
       expect(clearRefreshToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("syncSession", () => {
+    it("returns the customer without a refresh flag for a live session", async () => {
+      const { ensureFreshSession } = await import("@/lib/spree");
+      (ensureFreshSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        "valid",
+      );
+      mockClient.customer.get.mockResolvedValue(mockUser);
+
+      const result = await syncSession();
+
+      expect(result).toEqual({ customer: mockUser, refreshed: false });
+    });
+
+    it("flags a transparent refresh so the client can re-render", async () => {
+      const { ensureFreshSession } = await import("@/lib/spree");
+      (ensureFreshSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        "refreshed",
+      );
+      mockClient.customer.get.mockResolvedValue(mockUser);
+
+      const result = await syncSession();
+
+      expect(result).toEqual({ customer: mockUser, refreshed: true });
+    });
+
+    it("reports no customer for an expired session and skips the fetch", async () => {
+      const { ensureFreshSession } = await import("@/lib/spree");
+      (ensureFreshSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        "expired",
+      );
+
+      const result = await syncSession();
+
+      expect(result).toEqual({ customer: null, refreshed: false });
+      expect(mockClient.customer.get).not.toHaveBeenCalled();
+    });
+
+    it("reports no customer when anonymous", async () => {
+      const { ensureFreshSession } = await import("@/lib/spree");
+      (ensureFreshSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        "anonymous",
+      );
+
+      const result = await syncSession();
+
+      expect(result).toEqual({ customer: null, refreshed: false });
+      expect(mockClient.customer.get).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/data/cookies.ts
+++ b/src/lib/data/cookies.ts
@@ -1,7 +1,15 @@
 "use server";
 
-import { getAccessToken } from "@/lib/spree";
+import { getAccessToken, isJwtExpired } from "@/lib/spree";
 
+/**
+ * Whether the current request has a live customer session. A JWT cookie can
+ * outlive the token it holds (7-day cookie vs 1-hour JWT), so presence alone
+ * is not enough — an expired token reads as unauthenticated so the UI treats
+ * the session as logged out rather than showing an authenticated-looking shell
+ * over failing API calls.
+ */
 export async function isAuthenticated(): Promise<boolean> {
-  return !!(await getAccessToken());
+  const token = await getAccessToken();
+  return !!token && !isJwtExpired(token, 30);
 }

--- a/src/lib/data/customer.ts
+++ b/src/lib/data/customer.ts
@@ -7,6 +7,7 @@ import {
   clearAccessToken,
   clearCartCookies,
   clearRefreshToken,
+  ensureFreshSession,
   getAccessToken,
   getCartId,
   getCartToken,
@@ -17,6 +18,19 @@ import {
   withAuthRefresh,
 } from "@/lib/spree";
 import { actionResult } from "./utils";
+
+/**
+ * Clear auth cookies, tolerating a read-only (Server Component) context where
+ * cookie writes are not permitted.
+ */
+async function clearAuthTokens() {
+  try {
+    await clearAccessToken();
+    await clearRefreshToken();
+  } catch {
+    // Best-effort — not writable during a Server Component render.
+  }
+}
 
 /**
  * Post-auth bootstrap: store tokens, associate guest cart, invalidate caches.
@@ -62,11 +76,28 @@ export async function getCustomer(): Promise<Customer | null> {
       error instanceof SpreeError &&
       (error.status === 401 || error.status === 403)
     ) {
-      await clearAccessToken();
-      await clearRefreshToken();
+      await clearAuthTokens();
     }
     return null;
   }
+}
+
+/**
+ * Reconcile the customer session on the client: refresh an expired JWT when
+ * possible, then return the current customer. `refreshed` is true when a
+ * transparent token refresh occurred, signalling the client to re-render
+ * server components so their data reflects the renewed session.
+ */
+export async function syncSession(): Promise<{
+  customer: Customer | null;
+  refreshed: boolean;
+}> {
+  const state = await ensureFreshSession();
+  if (state === "anonymous" || state === "expired") {
+    return { customer: null, refreshed: false };
+  }
+  const customer = await getCustomer();
+  return { customer, refreshed: state === "refreshed" };
 }
 
 /**
@@ -204,8 +235,7 @@ export async function updateCustomer(data: {
         error instanceof SpreeError &&
         (error.status === 401 || error.status === 403)
       ) {
-        await clearAccessToken();
-        await clearRefreshToken();
+        await clearAuthTokens();
       }
       throw error;
     }

--- a/src/lib/spree/__tests__/jwt.test.ts
+++ b/src/lib/spree/__tests__/jwt.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { decodeJwtExp, isJwtExpired } from "@/lib/spree/jwt";
+
+/** Build a JWT-shaped string (header.payload.signature) with the given payload. */
+function makeToken(payload: Record<string, unknown>): string {
+  const b64 = (obj: Record<string, unknown>) =>
+    btoa(JSON.stringify(obj)).replace(/\+/g, "-").replace(/\//g, "_");
+  return `${b64({ alg: "HS256", typ: "JWT" })}.${b64(payload)}.sig`;
+}
+
+describe("decodeJwtExp", () => {
+  it("extracts a numeric exp claim", () => {
+    expect(decodeJwtExp(makeToken({ exp: 1_700_000_000 }))).toBe(1_700_000_000);
+  });
+
+  it("returns null for a token without exp", () => {
+    expect(decodeJwtExp(makeToken({ sub: "user" }))).toBeNull();
+  });
+
+  it("returns null for a malformed token", () => {
+    expect(decodeJwtExp("not-a-jwt")).toBeNull();
+    expect(decodeJwtExp("")).toBeNull();
+  });
+});
+
+describe("isJwtExpired", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("treats a future-dated token as live", () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    expect(isJwtExpired(makeToken({ exp }))).toBe(false);
+  });
+
+  it("treats a past-dated token as expired", () => {
+    const exp = Math.floor(Date.now() / 1000) - 10;
+    expect(isJwtExpired(makeToken({ exp }))).toBe(true);
+  });
+
+  it("treats a token inside the skew window as expired", () => {
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    expect(isJwtExpired(makeToken({ exp }), 300)).toBe(true);
+    expect(isJwtExpired(makeToken({ exp }), 30)).toBe(false);
+  });
+
+  it("treats an undecodable token as not expired (server decides)", () => {
+    expect(isJwtExpired("garbage")).toBe(false);
+  });
+});

--- a/src/lib/spree/auth-helpers.ts
+++ b/src/lib/spree/auth-helpers.ts
@@ -2,6 +2,7 @@ import type { RequestOptions } from "@spree/sdk";
 import { SpreeError } from "@spree/sdk";
 import { getClient } from "./config";
 import {
+  canPersistCookies,
   clearAccessToken,
   clearRefreshToken,
   getAccessToken,
@@ -9,6 +10,9 @@ import {
   setAccessToken,
   setRefreshToken,
 } from "./cookies";
+import { isJwtExpired } from "./jwt";
+
+export type SessionState = "valid" | "refreshed" | "expired" | "anonymous";
 
 /**
  * Get auth request options from the current JWT token.
@@ -20,21 +24,12 @@ export async function getAuthOptions(): Promise<RequestOptions> {
     return {};
   }
 
-  // Check if token is close to expiry by decoding JWT payload
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1]));
-    const exp = payload.exp;
-    const now = Math.floor(Date.now() / 1000);
-
-    // Refresh if token expires in less than 5 minutes
-    if (exp && exp - now < 300) {
-      const newToken = await tryRefresh();
-      if (newToken) {
-        return { token: newToken };
-      }
+  // Refresh proactively when the JWT is within 5 minutes of expiry.
+  if (isJwtExpired(token, 300)) {
+    const newToken = await tryRefresh();
+    if (newToken) {
+      return { token: newToken };
     }
-  } catch {
-    // Can't decode JWT — use it as-is, the server will reject if invalid
   }
 
   return { token };
@@ -67,9 +62,10 @@ export async function withAuthRefresh<T>(
       if (newToken) {
         return await fn({ token: newToken });
       }
-      // Refresh failed — clear all auth cookies and rethrow
-      await clearAccessToken();
-      await clearRefreshToken();
+      // Refresh failed — drop the auth cookies and rethrow. Best-effort: a
+      // Server Component render can't write cookies, in which case the client
+      // re-syncs the session from a Server Action instead.
+      await clearAuthCookies();
       throw error;
     }
     throw error;
@@ -77,12 +73,40 @@ export async function withAuthRefresh<T>(
 }
 
 /**
+ * Ensure the stored session has a live JWT, refreshing it when expired.
+ * Meant to be called from a Server Action (where cookies are writable) on
+ * client mount. The returned state lets the caller re-render server components
+ * after a transparent refresh.
+ */
+export async function ensureFreshSession(): Promise<SessionState> {
+  const token = await getAccessToken();
+  if (!token) return "anonymous";
+
+  if (!isJwtExpired(token, 30)) return "valid";
+
+  const newToken = await tryRefresh();
+  if (newToken) return "refreshed";
+
+  // Couldn't refresh — drop the stale session so the UI reflects logged-out.
+  await clearAuthCookies();
+  return "expired";
+}
+
+/**
  * Try to refresh the access token using the stored refresh token.
  * Returns the new access token on success, null on failure.
+ *
+ * The backend rotates the refresh token on every use, so the rotated value
+ * MUST be persisted. When the current context can't write cookies (a Server
+ * Component render), the network call is skipped rather than rotating a token
+ * that can't be stored — the client re-runs this from a Server Action.
  */
 async function tryRefresh(): Promise<string | null> {
   const refreshToken = await getRefreshToken();
   if (!refreshToken) return null;
+
+  // Don't rotate a refresh token we have no way to persist.
+  if (!(await canPersistCookies())) return null;
 
   try {
     const refreshed = await getClient().auth.refresh({
@@ -93,8 +117,16 @@ async function tryRefresh(): Promise<string | null> {
     return refreshed.token;
   } catch {
     // Refresh token is invalid/expired — clear it
-    await clearRefreshToken();
-    await clearAccessToken();
+    await clearAuthCookies();
     return null;
+  }
+}
+
+async function clearAuthCookies(): Promise<void> {
+  try {
+    await clearAccessToken();
+    await clearRefreshToken();
+  } catch {
+    // Cookie clears are best-effort — not writable during a Server Component render.
   }
 }

--- a/src/lib/spree/cookies.ts
+++ b/src/lib/spree/cookies.ts
@@ -8,6 +8,22 @@ const CART_TOKEN_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 const ACCESS_TOKEN_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
 const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 
+/**
+ * Whether the current execution context may write cookies. Next.js allows
+ * cookie mutation only in Server Actions and Route Handlers, never during a
+ * Server Component render. We probe with a harmless deletion of a throwaway
+ * cookie: it succeeds in a writable context and throws otherwise.
+ */
+export async function canPersistCookies(): Promise<boolean> {
+  try {
+    const cookieStore = await cookies();
+    cookieStore.set("_spree_write_probe", "", { maxAge: -1, path: "/" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function getCartCookieName(): string {
   try {
     return getConfig().cartCookieName ?? DEFAULT_CART_COOKIE;

--- a/src/lib/spree/index.ts
+++ b/src/lib/spree/index.ts
@@ -1,10 +1,16 @@
 // Configuration
 
 // Auth helpers (token refresh, cookie-based auth)
-export { getAuthOptions, withAuthRefresh } from "./auth-helpers";
+export {
+  ensureFreshSession,
+  getAuthOptions,
+  type SessionState,
+  withAuthRefresh,
+} from "./auth-helpers";
 export { getClient, getConfig, initSpreeNext } from "./config";
 // Cookie management
 export {
+  canPersistCookies,
   clearAccessToken,
   clearCartCookies,
   clearRefreshToken,
@@ -18,6 +24,8 @@ export {
   setCartCookies,
   setRefreshToken,
 } from "./cookies";
+// JWT helpers (expiry inspection, no signature verification)
+export { decodeJwtExp, isJwtExpired } from "./jwt";
 // Locale resolution (reads country/locale from cookies)
 export { getLocaleOptions } from "./locale";
 export type { SpreeNextConfig, SpreeNextOptions } from "./types";

--- a/src/lib/spree/jwt.ts
+++ b/src/lib/spree/jwt.ts
@@ -1,0 +1,28 @@
+/**
+ * Decode a JWT's `exp` claim (seconds since epoch) without verifying the
+ * signature. Returns null when the token is malformed or carries no `exp`.
+ */
+export function decodeJwtExp(token: string): number | null {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const json = JSON.parse(
+      atob(payload.replace(/-/g, "+").replace(/_/g, "/")),
+    );
+    return typeof json.exp === "number" ? json.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a JWT is expired, or expires within `skewSeconds`. A token that
+ * can't be decoded is treated as not-expired: the server stays the source of
+ * truth and rejects it if genuinely invalid.
+ */
+export function isJwtExpired(token: string, skewSeconds = 0): boolean {
+  const exp = decodeJwtExp(token);
+  if (exp === null) return false;
+  const now = Math.floor(Date.now() / 1000);
+  return exp - now <= skewSeconds;
+}


### PR DESCRIPTION
## Summary

Adds robust session management to the authentication system by implementing JWT expiry detection, transparent token refresh, and session re-sync when the browser tab regains focus. This ensures users remain authenticated across tab switches and prevents stale sessions from blocking checkout.

## Key Changes

- **JWT utilities** (`src/lib/spree/jwt.ts`): New module for decoding JWT `exp` claims and checking expiry with configurable skew windows, without signature verification.

- **Session refresh logic** (`src/lib/spree/auth-helpers.ts`):
  - Extracted JWT expiry checking into reusable `isJwtExpired()` helper
  - Added `ensureFreshSession()` Server Action to refresh expired JWTs and return session state (`valid`, `refreshed`, `expired`, `anonymous`)
  - Enhanced `tryRefresh()` to skip token rotation when cookies can't be persisted (Server Component context), deferring to client-side re-sync
  - Added `canPersistCookies()` probe to detect writable execution contexts

- **Session sync endpoint** (`src/lib/data/customer.ts`):
  - New `syncSession()` Server Action that reconciles client session state: refreshes expired JWTs and returns the current customer plus a `refreshed` flag
  - Consolidated auth cookie clearing into `clearAuthTokens()` helper with best-effort error handling

- **AuthContext enhancements** (`src/contexts/AuthContext.tsx`):
  - Integrated `syncSession()` for initial auth state and transparent JWT refresh
  - Added focus-driven re-sync: listens to `visibilitychange` and `focus` events to refresh session when tab regains visibility
  - Throttled re-sync to 30-second intervals to avoid excessive server calls
  - Calls `router.refresh()` after transparent token refresh to re-render server components with renewed session

- **Cookie authentication** (`src/lib/data/cookies.ts`):
  - Updated `isAuthenticated()` to check JWT expiry (30-second skew) in addition to token presence, preventing stale tokens from appearing authenticated

- **Checkout UX fix** (`src/components/checkout/AddressSection.tsx`):
  - Pre-populate email field with authenticated user's email
  - Only disable email field when both authenticated and email is present, preventing impossible checkout states with stale sessions

- **Comprehensive test coverage**:
  - `AuthContext.test.tsx`: Tests session sync on mount, focus-driven re-sync with throttling, transparent refresh triggering server re-render, and session expiry handling
  - `jwt.test.ts`: Tests JWT decoding, expiry detection with skew windows, and malformed token handling
  - `customer.test.ts`: Tests `syncSession()` behavior across all session states

## Implementation Details

- JWT expiry checks use a 5-minute proactive refresh window in API calls and 30-second skew in authentication checks, balancing security and UX
- Token rotation is deferred to Server Actions (where cookies are writable) rather than attempted during Server Component renders, preventing lost tokens
- Session re-sync on focus is throttled to prevent rapid tab switches from hammering the server while still catching JWT expiry during idle periods
- Transparent refresh (when JWT is renewed without user action) triggers `router.refresh()` to ensure server components re-fetch data with the new session

https://claude.ai/code/session_01X9CjDU8j8MvtR2Wtxpobfa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checkout now pre-fills the email address for signed-in customers when no email is already associated with the cart.
  * Signed-in customers can edit the checkout email when no saved email is available.
  * Expired sessions are now recognized and cleared more reliably.
  * Authentication stays synchronized when returning to or refocusing the app, with refreshes handled automatically.

* **Tests**
  * Added coverage for session synchronization, token expiration, refresh behavior, and checkout authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->