### PR TITLE
Harden session sync against false logouts and refresh races

### DIFF
--- a/src/components/checkout/AddressSection.tsx
+++ b/src/components/checkout/AddressSection.tsx
@@ -274,13 +274,14 @@ export function AddressSection({
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           onBlur={handleEmailBlur}
-          // Lock to the account email only when we actually have one — never
-          // leave the field both disabled and blank (a stale session would
-          // otherwise make checkout impossible).
-          disabled={isAuthenticated && !!email}
+          // Lock to the account email only when we actually have one — key off
+          // the account email, not the live input, so an authenticated user
+          // without an email on file can still type (and a stale session never
+          // leaves the field both disabled and blank, blocking checkout).
+          disabled={isAuthenticated && !!user?.email}
           placeholder={t("emailAddress")}
         />
-        {isAuthenticated && !!email && (
+        {isAuthenticated && !!user?.email && (
           <p className="text-xs text-gray-500 mt-1.5">
             {t("usingAccountEmail")}
           </p>

--- a/src/components/checkout/AddressSection.tsx
+++ b/src/components/checkout/AddressSection.tsx
@@ -96,10 +96,11 @@ export function AddressSection({
       : undefined;
 
   const [email, setEmail] = useState(cart.email || user?.email || "");
-  // Lock the email field to the account email only when one actually exists —
-  // key off the account email, not the live input, so an authenticated user
-  // without an email on file can still type (and a stale session never leaves
-  // the field both disabled and blank, blocking checkout).
+  // Lock the email field only once the account email is actually loaded. The
+  // server-derived `isAuthenticated` can be true while the AuthContext `user` is
+  // still null — during hydration, or after a transient sync is preserved as
+  // `stale` — so keying off `isAuthenticated` alone would leave the field
+  // disabled and blank, blocking checkout. Gate on the account email instead.
   const hasAccountEmail = isAuthenticated && !!user?.email;
   const defaultCountryIso = countries[0]?.iso ?? "";
 

--- a/src/components/checkout/AddressSection.tsx
+++ b/src/components/checkout/AddressSection.tsx
@@ -96,6 +96,11 @@ export function AddressSection({
       : undefined;
 
   const [email, setEmail] = useState(cart.email || user?.email || "");
+  // Lock the email field to the account email only when one actually exists —
+  // key off the account email, not the live input, so an authenticated user
+  // without an email on file can still type (and a stale session never leaves
+  // the field both disabled and blank, blocking checkout).
+  const hasAccountEmail = isAuthenticated && !!user?.email;
   const defaultCountryIso = countries[0]?.iso ?? "";
 
   const [shipAddress, setShipAddress] = useState<AddressFormData>(() => {
@@ -274,14 +279,10 @@ export function AddressSection({
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           onBlur={handleEmailBlur}
-          // Lock to the account email only when we actually have one — key off
-          // the account email, not the live input, so an authenticated user
-          // without an email on file can still type (and a stale session never
-          // leaves the field both disabled and blank, blocking checkout).
-          disabled={isAuthenticated && !!user?.email}
+          disabled={hasAccountEmail}
           placeholder={t("emailAddress")}
         />
-        {isAuthenticated && !!user?.email && (
+        {hasAccountEmail && (
           <p className="text-xs text-gray-500 mt-1.5">
             {t("usingAccountEmail")}
           </p>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -68,13 +68,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const refreshUser = useCallback(async () => {
     try {
       const { customer, refreshed, stale } = await syncSession();
+      // A transparent token rotation may have happened even when the follow-up
+      // fetch came back stale — re-render server components so they pick up the
+      // renewed session either way.
+      if (refreshed) {
+        router.refresh();
+      }
       // A transient fetch failure returns `stale` — keep the current session
       // rather than flashing the user to logged-out on a blip.
       if (stale) return;
       setUser(customer ? toUser(customer) : null);
-      if (refreshed) {
-        router.refresh();
-      }
     } catch {
       // Unexpected failure — leave the existing session untouched.
     }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -67,13 +67,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // stale session.
   const refreshUser = useCallback(async () => {
     try {
-      const { customer, refreshed } = await syncSession();
+      const { customer, refreshed, stale } = await syncSession();
+      // A transient fetch failure returns `stale` — keep the current session
+      // rather than flashing the user to logged-out on a blip.
+      if (stale) return;
       setUser(customer ? toUser(customer) : null);
       if (refreshed) {
         router.refresh();
       }
     } catch {
-      setUser(null);
+      // Unexpected failure — leave the existing session untouched.
     }
   }, [router]);
 

--- a/src/lib/data/__tests__/customer.test.ts
+++ b/src/lib/data/__tests__/customer.test.ts
@@ -25,6 +25,12 @@ vi.mock("@/lib/spree", () => ({
     },
   ),
   ensureFreshSession: vi.fn().mockResolvedValue("valid"),
+  isAuthError: (error: unknown) =>
+    !!error &&
+    typeof error === "object" &&
+    "status" in error &&
+    ((error as { status?: number }).status === 401 ||
+      (error as { status?: number }).status === 403),
   getAccessToken: vi.fn().mockResolvedValue("jwt-token"),
   setAccessToken: vi.fn(),
   clearAccessToken: vi.fn(),
@@ -187,6 +193,41 @@ describe("customer server actions", () => {
       });
       // A transient failure must not clear the session.
       expect(clearAuthCookies).not.toHaveBeenCalled();
+    });
+
+    it("preserves the session without fetching when the refresh is transiently stale", async () => {
+      const { ensureFreshSession, clearAuthCookies } = await import(
+        "@/lib/spree"
+      );
+      (ensureFreshSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        "stale",
+      );
+
+      const result = await syncSession();
+
+      expect(result).toEqual({
+        customer: null,
+        refreshed: false,
+        stale: true,
+      });
+      expect(mockClient.customer.get).not.toHaveBeenCalled();
+      expect(clearAuthCookies).not.toHaveBeenCalled();
+    });
+
+    it("keeps the refresh signal when a rotation is followed by a transient fetch failure", async () => {
+      const { ensureFreshSession } = await import("@/lib/spree");
+      (ensureFreshSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        "refreshed",
+      );
+      mockClient.customer.get.mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await syncSession();
+
+      expect(result).toEqual({
+        customer: null,
+        refreshed: true,
+        stale: true,
+      });
     });
 
     it("logs out (no stale flag) when the fetch returns an auth error", async () => {

--- a/src/lib/data/__tests__/customer.test.ts
+++ b/src/lib/data/__tests__/customer.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/lib/spree", () => ({
   getAccessToken: vi.fn().mockResolvedValue("jwt-token"),
   setAccessToken: vi.fn(),
   clearAccessToken: vi.fn(),
+  clearAuthCookies: vi.fn(),
   getRefreshToken: vi.fn().mockResolvedValue(undefined),
   setRefreshToken: vi.fn(),
   clearRefreshToken: vi.fn(),
@@ -101,11 +102,8 @@ describe("customer server actions", () => {
       const result = await getCustomer();
 
       expect(result).toBeNull();
-      const { clearAccessToken, clearRefreshToken } = await import(
-        "@/lib/spree"
-      );
-      expect(clearAccessToken).toHaveBeenCalled();
-      expect(clearRefreshToken).toHaveBeenCalled();
+      const { clearAuthCookies } = await import("@/lib/spree");
+      expect(clearAuthCookies).toHaveBeenCalled();
     });
 
     it("does not clear tokens on transient errors", async () => {
@@ -117,11 +115,8 @@ describe("customer server actions", () => {
       const result = await getCustomer();
 
       expect(result).toBeNull();
-      const { clearAccessToken, clearRefreshToken } = await import(
-        "@/lib/spree"
-      );
-      expect(clearAccessToken).not.toHaveBeenCalled();
-      expect(clearRefreshToken).not.toHaveBeenCalled();
+      const { clearAuthCookies } = await import("@/lib/spree");
+      expect(clearAuthCookies).not.toHaveBeenCalled();
     });
   });
 
@@ -172,6 +167,47 @@ describe("customer server actions", () => {
 
       expect(result).toEqual({ customer: null, refreshed: false });
       expect(mockClient.customer.get).not.toHaveBeenCalled();
+    });
+
+    it("marks the session stale on a transient fetch failure, preserving it", async () => {
+      const { ensureFreshSession, clearAuthCookies } = await import(
+        "@/lib/spree"
+      );
+      (ensureFreshSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        "valid",
+      );
+      mockClient.customer.get.mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await syncSession();
+
+      expect(result).toEqual({
+        customer: null,
+        refreshed: false,
+        stale: true,
+      });
+      // A transient failure must not clear the session.
+      expect(clearAuthCookies).not.toHaveBeenCalled();
+    });
+
+    it("logs out (no stale flag) when the fetch returns an auth error", async () => {
+      const { SpreeError } = await import("@spree/sdk");
+      const { ensureFreshSession, clearAuthCookies } = await import(
+        "@/lib/spree"
+      );
+      (ensureFreshSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        "valid",
+      );
+      mockClient.customer.get.mockRejectedValueOnce(
+        new SpreeError(
+          { error: { code: "unauthorized", message: "Unauthorized" } },
+          401,
+        ),
+      );
+
+      const result = await syncSession();
+
+      expect(result).toEqual({ customer: null, refreshed: false });
+      expect(clearAuthCookies).toHaveBeenCalled();
     });
   });
 

--- a/src/lib/data/customer.ts
+++ b/src/lib/data/customer.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import type { Customer } from "@spree/sdk";
-import { SpreeError } from "@spree/sdk";
 import { updateTag } from "next/cache";
 import {
   clearAccessToken,
@@ -14,23 +13,12 @@ import {
   getCartToken,
   getClient,
   getRefreshToken,
+  isAuthError,
   setAccessToken,
   setRefreshToken,
   withAuthRefresh,
 } from "@/lib/spree";
 import { actionResult } from "./utils";
-
-/**
- * Whether an error is a confirmed authentication failure (401/403) rather than
- * a transient network or server error. Only auth failures should log the user
- * out; transient failures must preserve the session.
- */
-function isAuthError(error: unknown): boolean {
-  return (
-    error instanceof SpreeError &&
-    (error.status === 401 || error.status === 403)
-  );
-}
 
 /**
  * Fetch the current customer with automatic token refresh. Throws on any
@@ -103,6 +91,11 @@ export async function syncSession(): Promise<{
   if (state === "anonymous" || state === "expired") {
     return { customer: null, refreshed: false };
   }
+  if (state === "stale") {
+    // The expired JWT couldn't be refreshed due to a transient failure — keep
+    // the current client session rather than logging out on a blip.
+    return { customer: null, refreshed: false, stale: true };
+  }
 
   try {
     const customer = await fetchCustomer();
@@ -112,8 +105,9 @@ export async function syncSession(): Promise<{
       await clearAuthCookies();
       return { customer: null, refreshed: false };
     }
-    // Transient failure — signal the client to preserve its current session.
-    return { customer: null, refreshed: false, stale: true };
+    // Transient failure — preserve the session. Still surface a rotation that
+    // did occur so the client re-renders server components under the new token.
+    return { customer: null, refreshed: state === "refreshed", stale: true };
   }
 }
 

--- a/src/lib/data/customer.ts
+++ b/src/lib/data/customer.ts
@@ -5,6 +5,7 @@ import { SpreeError } from "@spree/sdk";
 import { updateTag } from "next/cache";
 import {
   clearAccessToken,
+  clearAuthCookies,
   clearCartCookies,
   clearRefreshToken,
   ensureFreshSession,
@@ -20,16 +21,23 @@ import {
 import { actionResult } from "./utils";
 
 /**
- * Clear auth cookies, tolerating a read-only (Server Component) context where
- * cookie writes are not permitted.
+ * Whether an error is a confirmed authentication failure (401/403) rather than
+ * a transient network or server error. Only auth failures should log the user
+ * out; transient failures must preserve the session.
  */
-async function clearAuthTokens() {
-  try {
-    await clearAccessToken();
-    await clearRefreshToken();
-  } catch {
-    // Best-effort — not writable during a Server Component render.
-  }
+function isAuthError(error: unknown): boolean {
+  return (
+    error instanceof SpreeError &&
+    (error.status === 401 || error.status === 403)
+  );
+}
+
+/**
+ * Fetch the current customer with automatic token refresh. Throws on any
+ * failure (auth or transient) so callers can distinguish the two.
+ */
+async function fetchCustomer(): Promise<Customer> {
+  return withAuthRefresh((options) => getClient().customer.get(options));
 }
 
 /**
@@ -67,16 +75,12 @@ export async function getCustomer(): Promise<Customer | null> {
   if (!token) return null;
 
   try {
-    return await withAuthRefresh(async (options) => {
-      return getClient().customer.get(options);
-    });
+    return await fetchCustomer();
   } catch (error) {
-    // Only clear tokens on auth failures — transient errors should not log users out
-    if (
-      error instanceof SpreeError &&
-      (error.status === 401 || error.status === 403)
-    ) {
-      await clearAuthTokens();
+    // Only clear tokens on confirmed auth failures — transient errors (network,
+    // 5xx) must not log users out.
+    if (isAuthError(error)) {
+      await clearAuthCookies();
     }
     return null;
   }
@@ -86,18 +90,31 @@ export async function getCustomer(): Promise<Customer | null> {
  * Reconcile the customer session on the client: refresh an expired JWT when
  * possible, then return the current customer. `refreshed` is true when a
  * transparent token refresh occurred, signalling the client to re-render
- * server components so their data reflects the renewed session.
+ * server components so their data reflects the renewed session. `stale` is true
+ * when the customer fetch failed transiently — the caller should keep its
+ * current session rather than treat it as logged out.
  */
 export async function syncSession(): Promise<{
   customer: Customer | null;
   refreshed: boolean;
+  stale?: boolean;
 }> {
   const state = await ensureFreshSession();
   if (state === "anonymous" || state === "expired") {
     return { customer: null, refreshed: false };
   }
-  const customer = await getCustomer();
-  return { customer, refreshed: state === "refreshed" };
+
+  try {
+    const customer = await fetchCustomer();
+    return { customer, refreshed: state === "refreshed" };
+  } catch (error) {
+    if (isAuthError(error)) {
+      await clearAuthCookies();
+      return { customer: null, refreshed: false };
+    }
+    // Transient failure — signal the client to preserve its current session.
+    return { customer: null, refreshed: false, stale: true };
+  }
 }
 
 /**
@@ -231,11 +248,8 @@ export async function updateCustomer(data: {
         return getClient().customer.update(data, options);
       });
     } catch (error) {
-      if (
-        error instanceof SpreeError &&
-        (error.status === 401 || error.status === 403)
-      ) {
-        await clearAuthTokens();
+      if (isAuthError(error)) {
+        await clearAuthCookies();
       }
       throw error;
     }

--- a/src/lib/spree/__tests__/auth-helpers.test.ts
+++ b/src/lib/spree/__tests__/auth-helpers.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Outer state referenced inside vi.mock factories must be `mock`-prefixed so
+// Vitest allows it past the hoisting guard.
+const mockClient = { auth: { refresh: vi.fn() } };
+const mockCookieState: { access?: string; refresh?: string } = {};
+const mockCanPersist = vi.fn(async () => true);
+const mockIsJwtExpired = vi.fn(() => true);
+const mockClearAccessToken = vi.fn(async () => {
+  mockCookieState.access = undefined;
+});
+const mockClearRefreshToken = vi.fn(async () => {
+  mockCookieState.refresh = undefined;
+});
+const mockSetAccessToken = vi.fn(async (token: string) => {
+  mockCookieState.access = token;
+});
+const mockSetRefreshToken = vi.fn(async (token: string) => {
+  mockCookieState.refresh = token;
+});
+
+vi.mock("../config", () => ({ getClient: () => mockClient }));
+vi.mock("../jwt", () => ({ isJwtExpired: () => mockIsJwtExpired() }));
+vi.mock("../cookies", () => ({
+  getAccessToken: async () => mockCookieState.access,
+  getRefreshToken: async () => mockCookieState.refresh,
+  canPersistCookies: () => mockCanPersist(),
+  setAccessToken: (token: string) => mockSetAccessToken(token),
+  setRefreshToken: (token: string) => mockSetRefreshToken(token),
+  clearAccessToken: () => mockClearAccessToken(),
+  clearRefreshToken: () => mockClearRefreshToken(),
+}));
+
+vi.mock("@spree/sdk", () => ({
+  SpreeError: class SpreeError extends Error {
+    code: string;
+    status: number;
+    constructor(
+      response: { error: { code: string; message: string } },
+      status: number,
+    ) {
+      super(response.error.message);
+      this.code = response.error.code;
+      this.status = status;
+    }
+  },
+}));
+
+import { ensureFreshSession } from "../auth-helpers";
+
+describe("ensureFreshSession refresh resilience", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.auth.refresh.mockReset();
+    mockCookieState.access = "expired-jwt";
+    mockCookieState.refresh = "rt-1";
+  });
+
+  it("preserves the session when the refresh call fails transiently", async () => {
+    mockClient.auth.refresh.mockRejectedValueOnce(new Error("network down"));
+
+    const state = await ensureFreshSession();
+
+    expect(state).toBe("stale");
+    expect(mockClearAccessToken).not.toHaveBeenCalled();
+    expect(mockClearRefreshToken).not.toHaveBeenCalled();
+    expect(mockCookieState.refresh).toBe("rt-1");
+  });
+
+  it("drops the session when the refresh token is confirmed invalid", async () => {
+    const { SpreeError } = await import("@spree/sdk");
+    mockClient.auth.refresh.mockRejectedValueOnce(
+      new SpreeError(
+        { error: { code: "invalid_refresh_token", message: "Invalid" } },
+        401,
+      ),
+    );
+
+    const state = await ensureFreshSession();
+
+    expect(state).toBe("expired");
+    expect(mockClearAccessToken).toHaveBeenCalled();
+    expect(mockClearRefreshToken).toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent refreshes sharing a token into a single call", async () => {
+    mockClient.auth.refresh.mockImplementation(async () => {
+      // Yield once so both callers reach the in-flight map before resolving.
+      await Promise.resolve();
+      return { token: "new-jwt", refresh_token: "rt-2" };
+    });
+
+    const [first, second] = await Promise.all([
+      ensureFreshSession(),
+      ensureFreshSession(),
+    ]);
+
+    expect(first).toBe("refreshed");
+    expect(second).toBe("refreshed");
+    expect(mockClient.auth.refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/spree/auth-helpers.ts
+++ b/src/lib/spree/auth-helpers.ts
@@ -12,7 +12,24 @@ import {
 } from "./cookies";
 import { isJwtExpired } from "./jwt";
 
-export type SessionState = "valid" | "refreshed" | "expired" | "anonymous";
+export type SessionState =
+  | "valid"
+  | "refreshed"
+  | "expired"
+  | "anonymous"
+  | "stale";
+
+/**
+ * Whether an error is a confirmed authentication failure (401/403) rather than a
+ * transient network or server error. Only confirmed auth failures should drop
+ * the session; transient failures must preserve it so a later retry can recover.
+ */
+export function isAuthError(error: unknown): boolean {
+  return (
+    error instanceof SpreeError &&
+    (error.status === 401 || error.status === 403)
+  );
+}
 
 /**
  * Get auth request options from the current JWT token.
@@ -62,10 +79,9 @@ export async function withAuthRefresh<T>(
       if (newToken) {
         return await fn({ token: newToken });
       }
-      // Refresh failed — drop the auth cookies and rethrow. Best-effort: a
-      // Server Component render can't write cookies, in which case the client
-      // re-syncs the session from a Server Action instead.
-      await clearAuthCookies();
+      // tryRefresh drops the session only when the refresh token is confirmed
+      // invalid; a transient failure leaves it intact so the client can retry.
+      // Rethrow the original 401 either way.
       throw error;
     }
     throw error;
@@ -87,9 +103,11 @@ export async function ensureFreshSession(): Promise<SessionState> {
   const newToken = await tryRefresh();
   if (newToken) return "refreshed";
 
-  // Couldn't refresh — drop the stale session so the UI reflects logged-out.
-  await clearAuthCookies();
-  return "expired";
+  // Refresh failed. tryRefresh drops the cookies only when the refresh token is
+  // confirmed invalid; if they survive, the failure was transient — report
+  // `stale` so the caller preserves the session instead of logging out on a blip.
+  const refreshToken = await getRefreshToken();
+  return refreshToken ? "stale" : "expired";
 }
 
 // Coalesces concurrent refreshes that share the same rotated refresh token.
@@ -126,9 +144,13 @@ async function tryRefresh(): Promise<string | null> {
       await setAccessToken(refreshed.token);
       await setRefreshToken(refreshed.refresh_token);
       return refreshed.token;
-    } catch {
-      // Refresh token is invalid/expired — clear it
-      await clearAuthCookies();
+    } catch (error) {
+      // Only a confirmed-invalid refresh token means the session is truly dead.
+      // Transient failures (network, 5xx) must preserve the session so a later
+      // retry can recover rather than logging the user out on a blip.
+      if (isAuthError(error)) {
+        await clearAuthCookies();
+      }
       return null;
     } finally {
       refreshInFlight.delete(refreshToken);

--- a/src/lib/spree/auth-helpers.ts
+++ b/src/lib/spree/auth-helpers.ts
@@ -92,6 +92,13 @@ export async function ensureFreshSession(): Promise<SessionState> {
   return "expired";
 }
 
+// Coalesces concurrent refreshes that share the same rotated refresh token.
+// The backend invalidates a refresh token once it's used, so two in-flight
+// refreshes racing on the same token would leave the loser rotating a
+// now-stale token and clearing the freshly persisted session. Keyed by the
+// token value so distinct sessions never share a refresh.
+const refreshInFlight = new Map<string, Promise<string | null>>();
+
 /**
  * Try to refresh the access token using the stored refresh token.
  * Returns the new access token on success, null on failure.
@@ -108,21 +115,31 @@ async function tryRefresh(): Promise<string | null> {
   // Don't rotate a refresh token we have no way to persist.
   if (!(await canPersistCookies())) return null;
 
-  try {
-    const refreshed = await getClient().auth.refresh({
-      refresh_token: refreshToken,
-    });
-    await setAccessToken(refreshed.token);
-    await setRefreshToken(refreshed.refresh_token);
-    return refreshed.token;
-  } catch {
-    // Refresh token is invalid/expired — clear it
-    await clearAuthCookies();
-    return null;
-  }
+  const existing = refreshInFlight.get(refreshToken);
+  if (existing) return existing;
+
+  const refresh = (async () => {
+    try {
+      const refreshed = await getClient().auth.refresh({
+        refresh_token: refreshToken,
+      });
+      await setAccessToken(refreshed.token);
+      await setRefreshToken(refreshed.refresh_token);
+      return refreshed.token;
+    } catch {
+      // Refresh token is invalid/expired — clear it
+      await clearAuthCookies();
+      return null;
+    } finally {
+      refreshInFlight.delete(refreshToken);
+    }
+  })();
+
+  refreshInFlight.set(refreshToken, refresh);
+  return refresh;
 }
 
-async function clearAuthCookies(): Promise<void> {
+export async function clearAuthCookies(): Promise<void> {
   try {
     await clearAccessToken();
     await clearRefreshToken();

--- a/src/lib/spree/index.ts
+++ b/src/lib/spree/index.ts
@@ -2,6 +2,7 @@
 
 // Auth helpers (token refresh, cookie-based auth)
 export {
+  clearAuthCookies,
   ensureFreshSession,
   getAuthOptions,
   type SessionState,

--- a/src/lib/spree/index.ts
+++ b/src/lib/spree/index.ts
@@ -5,6 +5,7 @@ export {
   clearAuthCookies,
   ensureFreshSession,
   getAuthOptions,
+  isAuthError,
   type SessionState,
   withAuthRefresh,
 } from "./auth-helpers";


### PR DESCRIPTION
## Summary

Follow-up to #171 (session sync with JWT refresh on tab focus), addressing review findings from that PR that landed alongside the merge.

## Changes

- **Checkout email no longer locks mid-typing** (`AddressSection.tsx`) — the field's `disabled`/helper condition now keys off the account email (`user?.email`) instead of the live input state. Previously an authenticated user with no email on file would have the field disable itself after the first keystroke, blocking checkout.
- **Transient fetch failures don't force a logout** (`customer.ts`, `AuthContext.tsx`) — `syncSession()` now flags a transient customer-fetch failure as `stale` so the client keeps the current user rather than flashing to logged-out on a network blip / 5xx. The session is only cleared on a confirmed `401`/`403`.
- **Concurrent token refreshes are coalesced** (`auth-helpers.ts`) — `tryRefresh()` now shares a single in-flight request per rotated refresh token, so a losing race can no longer rotate a stale token and wipe the freshly persisted session. Keyed by token value so distinct sessions never share a refresh.
- **Deduplicated cookie clearing** — `clearAuthCookies()` is exported from `auth-helpers` and reused in `customer.ts` in place of the duplicate `clearAuthTokens()` helper.

## Testing

- `vitest run` — 106 tests pass, including new `syncSession` cases covering the transient-failure (`stale`) and auth-failure paths.
- `tsc --noEmit` clean; Biome check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9CjDU8j8MvtR2Wtxpobfa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkout email field behavior for authenticated customers by gating disable/notice on account email availability.
  * Prevented temporary session or network issues from unnecessarily signing customers out.
  * Authentication cookies are now cleared only after confirmed authentication failures.
  * Improved reliability when multiple session refreshes occur simultaneously, including “stale” handling for transient issues.
* **Tests**
  * Expanded coverage for transient vs confirmed auth failures, “stale” session outcomes, and concurrent session refresh coalescing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication, cookie clearing, and token refresh—security-sensitive paths—but behavior is narrowed (fewer logouts) with added tests; checkout UX change is low scope.
> 
> **Overview**
> Hardens JWT session handling so **network blips and concurrent refreshes no longer sign users out or break checkout**.
> 
> **Session sync** — `syncSession()` can return `stale` when refresh or customer fetch fails transiently; `AuthContext` keeps the in-memory user instead of clearing it. Cookies are cleared only on confirmed **401/403** via shared `isAuthError` / `clearAuthCookies`. `ensureFreshSession()` adds a **`stale`** state when refresh fails but the refresh token remains; `tryRefresh()` no longer wipes cookies on generic errors.
> 
> **Refresh races** — Concurrent refreshes for the same refresh token are **coalesced** so a losing race cannot rotate an already-invalidated token and wipe a good session.
> 
> **Checkout** — The email field locks only when **`user?.email`** is present (`hasAccountEmail`), not when `isAuthenticated` is true while `user` is still null (hydration or stale sync), avoiding a disabled blank email field.
> 
> Tests cover stale vs auth-failure paths and refresh coalescing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699febaec49e42b34819dc4b4a013d449d5627d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->