### PR TITLE
Add dependency overrides for postcss and mute-stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2198,6 +2198,15 @@
         }
       }
     },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@inquirer/figures": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.6.tgz",
@@ -4662,9 +4671,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4682,9 +4688,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4702,9 +4705,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4722,9 +4722,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4742,9 +4739,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4762,9 +4756,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10483,15 +10474,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mute-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-4.0.0.tgz",
-      "integrity": "sha512-gSrprq0fJ3EiOErzjdIZrjysVVmJ4uu1QWfCDss5LypA5OXvrMje5Ym5z6V6RLyJ2eF87lasX7t6a0AnFvZblg==",
-      "license": "ISC",
-      "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -10633,34 +10615,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-addon-api": {
@@ -11233,9 +11187,9 @@
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "tw-animate-css": "^1.4.0"
   },
   "overrides": {
-    "minimatch": "^10.2.1"
+    "minimatch": "^10.2.1",
+    "postcss": "^8.5.10",
+    "mute-stream": "^3.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",


### PR DESCRIPTION
## Summary
Added npm dependency overrides for `postcss` and `mute-stream` to ensure consistent versions across the project's dependency tree.

## Changes
- Added `postcss@^8.5.10` override to the `overrides` field in package.json
- Added `mute-stream@^3.0.0` override to the `overrides` field in package.json

## Details
These overrides help resolve transitive dependency conflicts by pinning specific versions of these packages that may be required by other dependencies in the project. This ensures all packages use compatible versions and prevents version conflicts during installation.

https://claude.ai/code/session_01EWnpuwP72r5UA15HtmwuCP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version overrides for improved compatibility and stability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->