### PR TITLE
Fix infinite redirect for region-specific locales

### DIFF
--- a/src/lib/spree/middleware.ts
+++ b/src/lib/spree/middleware.ts
@@ -4,7 +4,7 @@ const COUNTRY_COOKIE = "spree_country";
 const LOCALE_COOKIE = "spree_locale";
 const COOKIE_MAX_AGE = 365 * 24 * 60 * 60;
 
-const HAS_COUNTRY_LOCALE = /^\/([a-z]{2})\/([a-z]{2})(\/|$)/i;
+const HAS_COUNTRY_LOCALE = /^\/([a-z]{2})\/([a-z]{2}(?:-[a-z]{2})?)(\/|$)/i;
 
 export interface SpreeMiddlewareConfig {
   /** Default country ISO code (default: 'us') */


### PR DESCRIPTION
## Summary

Fixes an infinite redirect when the locale contains a region suffix (e.g. `en-GB`, `pt-BR`).

## Problem

The middleware regex only matched two-letter locale codes:

```ts
/^\/([a-z]{2})\/([a-z]{2})(\/|$)/i
```

As a result, URLs like `/gb/en-GB` were not recognized as valid `{country}/{locale}` paths. The middleware treated them as missing the locale prefix and kept redirecting, resulting in an infinite redirect loop.

## Solution

Update the locale matching regex to support locales with an optional region suffix:

```ts
/^\/([a-z]{2})\/([a-z]{2}(?:-[a-z]{2})?)(\/|$)/i
```

## Testing

Verified locally with:

- `/gb/en`
- `/gb/en-GB`

Both routes are recognized correctly, and the redirect loop is resolved.

Fixes #<issue-number>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale detection for URLs using regional formats such as `en-US`.
  * Prevented unnecessary redirects when country and locale information is already included in the URL.
  * Kept country and locale settings synchronized with the URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->