### PR TITLE
Sort countries alphabetically across markets

### DIFF
--- a/src/contexts/StoreContext.tsx
+++ b/src/contexts/StoreContext.tsx
@@ -50,7 +50,7 @@ function buildCountriesFromMarkets(markets: Market[]): CountryWithMarket[] {
     }
   }
 
-  return result;
+  return result.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /** Find a country by ISO code in the flat countries list. */


### PR DESCRIPTION
## Summary

Fix the country list sorting so that all countries are displayed in a single alphabetical order.

## Problem

Countries were displayed based on the order of markets returned from the API.

Because countries were grouped by market, the complete list was not sorted alphabetically as a single group. This made it harder for users to find their country in the list.

## Solution

After building the flattened country list from all markets, sort the final list alphabetically by country name.

```ts
return result.sort((a, b) => a.name.localeCompare(b.name));
```

## Testing

Tested locally and verified that countries are now displayed as one alphabetical list.

Fixes #142