### PR TITLE
fix product description multiline line breaks

### DIFF
--- a/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
+++ b/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
@@ -214,7 +214,7 @@ export function ProductDetails({ product, basePath }: ProductDetailsProps) {
               {/* Description is admin-authored HTML from the Spree CMS backend (trusted source) */}
               <div
                 className="text-gray-600 prose prose-sm max-w-none"
-                dangerouslySetInnerHTML={{ __html: product.description }}
+                dangerouslySetInnerHTML={{ __html: product.description_html ?? '' }}
               />
             </div>
           )}

--- a/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
+++ b/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
@@ -215,7 +215,7 @@ export function ProductDetails({ product, basePath }: ProductDetailsProps) {
               <div
                 className="text-gray-600 prose prose-sm max-w-none"
                 dangerouslySetInnerHTML={{
-                  __html: product.description_html ?? ""
+                  __html: product.description_html ?? "",
                 }}
               />
             </div>

--- a/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
+++ b/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
@@ -214,9 +214,7 @@ export function ProductDetails({ product, basePath }: ProductDetailsProps) {
               {/* Description is admin-authored HTML from the Spree CMS backend (trusted source) */}
               <div
                 className="text-gray-600 prose prose-sm max-w-none"
-                dangerouslySetInnerHTML={{
-                    __html: product.description_html ?? "",
-                  }}
+                dangerouslySetInnerHTML={{ __html: product.description_html ?? "" }}
               />
             </div>
           )}

--- a/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
+++ b/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
@@ -214,7 +214,9 @@ export function ProductDetails({ product, basePath }: ProductDetailsProps) {
               {/* Description is admin-authored HTML from the Spree CMS backend (trusted source) */}
               <div
                 className="text-gray-600 prose prose-sm max-w-none"
-                dangerouslySetInnerHTML={{ __html: product.description_html ?? "" }}
+                dangerouslySetInnerHTML={{
+                  __html: product.description_html ?? ""
+                }}
               />
             </div>
           )}

--- a/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
+++ b/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
@@ -214,7 +214,9 @@ export function ProductDetails({ product, basePath }: ProductDetailsProps) {
               {/* Description is admin-authored HTML from the Spree CMS backend (trusted source) */}
               <div
                 className="text-gray-600 prose prose-sm max-w-none"
-                dangerouslySetInnerHTML={{ __html: product.description_html ?? '' }}
+                dangerouslySetInnerHTML={{
+                    __html: product.description_html ?? "",
+                  }}
               />
             </div>
           )}


### PR DESCRIPTION
Use product.description_html instead of product.description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Product descriptions now display the provided formatted HTML content correctly.
  * Added a fallback for products without description content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->