### PR TITLE
Add additional `SPREE_IMAGES_URL` env to override the allowed host URLs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,17 +10,22 @@ const withNextIntl = createNextIntlPlugin();
  * returns Active Storage URLs on its own host (which may differ from
  * SPREE_API_URL's — e.g. store URL vs API URL, http vs https, with or without a
  * port), so we allow the SPREE_API_URL hostname over both protocols and any
- * port rather than hardcoding specific hosts. The pathname stays scoped to
- * Active Storage. Falls back to `localhost` when SPREE_API_URL is unset (dev).
+ * port rather than hardcoding specific hosts. Set SPREE_IMAGES_URL when images
+ * are served from a different host than the API — e.g. spree.sh puts images
+ * behind a CDN (console.spree.sh) — and it takes precedence over SPREE_API_URL.
+ * The pathname stays scoped to Active Storage. Falls back to `localhost` when
+ * neither variable is set (dev).
  */
 function spreeImagePatterns(): RemotePattern[] {
-  const raw = process.env.SPREE_API_URL?.trim();
+  const raw = (
+    process.env.SPREE_IMAGES_URL || process.env.SPREE_API_URL
+  )?.trim();
   let hostname = "localhost";
   if (raw) {
     try {
       hostname = new URL(raw).hostname;
     } catch {
-      // Malformed SPREE_API_URL — keep the localhost fallback.
+      // Malformed URL — keep the localhost fallback.
     }
   }
   const pathname = "/rails/active_storage/**";
@@ -62,7 +67,7 @@ const nextConfig: NextConfig = {
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     remotePatterns: [
-      // Derived from SPREE_API_URL — the backend the storefront points at.
+      // Derived from SPREE_IMAGES_URL (if set) or SPREE_API_URL.
       ...spreeImagePatterns(),
       // Hosted demo / tunnel backends whose image host differs from SPREE_API_URL.
     ],


### PR DESCRIPTION
If using CDN with Spree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image handling to use the configured image service URL when available.
  * Preserved compatibility with API URL settings and local development environments.
  * Improved support for loading remote images from the correct configured host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->