### PR TITLE
Refactor QuantityPicker to support direct input and improve UX

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1,5 +1,8 @@
 {
   "common": {
+    "decreaseQuantity": "Menge verringern",
+    "increaseQuantity": "Menge erhöhen",
+    "quantity": "Menge",
     "subtotal": "Zwischensumme",
     "shipping": "Versand",
     "tax": "Steuer",
@@ -98,8 +101,6 @@
     "emptyCart": "Ihr Warenkorb ist leer",
     "emptyCartDescription": "Es sieht so aus, als hätten Sie noch nichts in Ihren Warenkorb gelegt.",
     "removeItem": "Artikel entfernen",
-    "decreaseQuantity": "Menge verringern",
-    "increaseQuantity": "Menge erhöhen",
     "shippingNote": "Versand und Steuern werden an der Kasse berechnet",
     "checkout": "Zur Kasse",
     "viewCart": "Warenkorb anzeigen",
@@ -165,8 +166,6 @@
     "noImageAvailable": "Kein Bild verfügbar",
     "clickToZoom": "Zum Vergrößern klicken",
     "noProductsMatchingFilters": "Keine Produkte gefunden, die Ihren Filtern entsprechen.",
-    "decreaseQuantity": "Menge verringern",
-    "increaseQuantity": "Menge erhöhen",
     "carouselPrev": "Vorherige Produkte",
     "carouselNext": "Nächste Produkte",
     "lightboxClose": "Lightbox schließen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,8 @@
 {
   "common": {
+    "decreaseQuantity": "Decrease quantity",
+    "increaseQuantity": "Increase quantity",
+    "quantity": "Quantity",
     "subtotal": "Subtotal",
     "shipping": "Shipping",
     "tax": "Tax",
@@ -98,8 +101,6 @@
     "emptyCart": "Your cart is empty",
     "emptyCartDescription": "Looks like you haven't added anything to your cart yet.",
     "removeItem": "Remove item",
-    "decreaseQuantity": "Decrease quantity",
-    "increaseQuantity": "Increase quantity",
     "shippingNote": "Shipping and taxes calculated at checkout",
     "checkout": "Checkout",
     "viewCart": "View Cart",
@@ -165,8 +166,6 @@
     "noImageAvailable": "No image available",
     "clickToZoom": "Click to zoom",
     "noProductsMatchingFilters": "No products found matching your filters.",
-    "decreaseQuantity": "Decrease quantity",
-    "increaseQuantity": "Increase quantity",
     "carouselPrev": "Previous products",
     "carouselNext": "Next products",
     "lightboxClose": "Close lightbox",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,5 +1,8 @@
 {
   "common": {
+    "decreaseQuantity": "Disminuir cantidad",
+    "increaseQuantity": "Aumentar cantidad",
+    "quantity": "Cantidad",
     "subtotal": "Subtotal",
     "shipping": "Envio",
     "tax": "Impuestos",
@@ -98,8 +101,6 @@
     "emptyCart": "Tu carrito esta vacio",
     "emptyCartDescription": "Parece que aun no has agregado nada a tu carrito.",
     "removeItem": "Eliminar articulo",
-    "decreaseQuantity": "Disminuir cantidad",
-    "increaseQuantity": "Aumentar cantidad",
     "shippingNote": "Envio e impuestos calculados en el checkout",
     "checkout": "Pagar",
     "viewCart": "Ver carrito",
@@ -165,8 +166,6 @@
     "noImageAvailable": "Imagen no disponible",
     "clickToZoom": "Clic para ampliar",
     "noProductsMatchingFilters": "No se encontraron productos que coincidan con tus filtros.",
-    "decreaseQuantity": "Disminuir cantidad",
-    "increaseQuantity": "Aumentar cantidad",
     "carouselPrev": "Productos anteriores",
     "carouselNext": "Productos siguientes",
     "lightboxClose": "Cerrar visor",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,5 +1,8 @@
 {
   "common": {
+    "decreaseQuantity": "Diminuer la quantité",
+    "increaseQuantity": "Augmenter la quantité",
+    "quantity": "Quantité",
     "subtotal": "Sous-total",
     "shipping": "Livraison",
     "tax": "Taxes",
@@ -98,8 +101,6 @@
     "emptyCart": "Votre panier est vide",
     "emptyCartDescription": "Il semble que vous n'ayez encore rien ajoute a votre panier.",
     "removeItem": "Supprimer l'article",
-    "decreaseQuantity": "Diminuer la quantite",
-    "increaseQuantity": "Augmenter la quantite",
     "shippingNote": "Livraison et taxes calculees lors du paiement",
     "checkout": "Passer la commande",
     "viewCart": "Voir le panier",
@@ -165,8 +166,6 @@
     "noImageAvailable": "Aucune image disponible",
     "clickToZoom": "Cliquez pour agrandir",
     "noProductsMatchingFilters": "Aucun produit ne correspond a vos filtres.",
-    "decreaseQuantity": "Diminuer la quantite",
-    "increaseQuantity": "Augmenter la quantite",
     "carouselPrev": "Produits precedents",
     "carouselNext": "Produits suivants",
     "lightboxClose": "Fermer la visionneuse",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1,5 +1,8 @@
 {
   "common": {
+    "decreaseQuantity": "Zmniejsz ilość",
+    "increaseQuantity": "Zwiększ ilość",
+    "quantity": "Ilość",
     "subtotal": "Suma częściowa",
     "shipping": "Wysyłka",
     "tax": "Podatek",
@@ -98,8 +101,6 @@
     "emptyCart": "Twój koszyk jest pusty",
     "emptyCartDescription": "Wygląda na to, że nie dodałeś jeszcze nic do koszyka.",
     "removeItem": "Usuń produkt",
-    "decreaseQuantity": "Zmniejsz ilość",
-    "increaseQuantity": "Zwiększ ilość",
     "shippingNote": "Koszty wysyłki i podatki zostaną obliczone przy kasie",
     "checkout": "Do kasy",
     "viewCart": "Zobacz koszyk",
@@ -165,8 +166,6 @@
     "noImageAvailable": "Brak zdjęcia",
     "clickToZoom": "Kliknij aby powiększyć",
     "noProductsMatchingFilters": "Nie znaleziono produktów pasujących do wybranych filtrów.",
-    "decreaseQuantity": "Zmniejsz ilość",
-    "increaseQuantity": "Zwiększ ilość",
     "carouselPrev": "Poprzednie produkty",
     "carouselNext": "Następne produkty",
     "lightboxClose": "Zamknij podgląd",

--- a/src/app/[country]/[locale]/(storefront)/cart/page.tsx
+++ b/src/app/[country]/[locale]/(storefront)/cart/page.tsx
@@ -7,9 +7,9 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
+import { QuantityPickerField } from "@/components/cart/QuantityPickerField";
 import { Button } from "@/components/ui/button";
 import { ProductImage } from "@/components/ui/product-image";
-import { QuantityPicker } from "@/components/ui/quantity-picker";
 import { useCart } from "@/contexts/CartContext";
 import { trackRemoveFromCart, trackViewCart } from "@/lib/analytics/gtm";
 import { extractBasePath } from "@/lib/utils/path";
@@ -130,12 +130,11 @@ export default function CartPage() {
 
                 {/* Quantity & Actions */}
                 <div className="flex flex-col items-end gap-2">
-                  <QuantityPicker
+                  <QuantityPickerField
                     quantity={item.quantity}
-                    onDecrement={() =>
-                      updateItem(item.id, Math.max(1, item.quantity - 1))
+                    onQuantityChange={(quantity) =>
+                      updateItem(item.id, quantity)
                     }
-                    onIncrement={() => updateItem(item.id, item.quantity + 1)}
                   />
                   <Button
                     variant="destructive"

--- a/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
+++ b/src/app/[country]/[locale]/(storefront)/products/[slug]/ProductDetails.tsx
@@ -5,12 +5,12 @@ import { CircleCheckBig, CircleX, Loader2, ShoppingBag } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
+import { QuantityPickerField } from "@/components/cart/QuantityPickerField";
 import { HiddenPricePrompt } from "@/components/products/HiddenPricePrompt";
 import { MediaGallery } from "@/components/products/MediaGallery";
 import { ProductCustomFields } from "@/components/products/ProductCustomFields";
 import { VariantPicker } from "@/components/products/VariantPicker";
 import { Button } from "@/components/ui/button";
-import { QuantityPicker } from "@/components/ui/quantity-picker";
 import { useCart } from "@/contexts/CartContext";
 import { useHiddenPricing } from "@/contexts/HiddenPricingContext";
 import { useStore } from "@/contexts/StoreContext";
@@ -194,10 +194,9 @@ export function ProductDetails({ product, basePath }: ProductDetailsProps) {
               </Button>
             ) : (
               <div className="flex gap-4">
-                <QuantityPicker
+                <QuantityPickerField
                   quantity={quantity}
-                  onDecrement={() => setQuantity(Math.max(1, quantity - 1))}
-                  onIncrement={() => setQuantity(quantity + 1)}
+                  onQuantityChange={setQuantity}
                   size="lg"
                 />
 

--- a/src/app/[country]/[locale]/(wholesale)/wholesale/cart/WholesaleCartView.tsx
+++ b/src/app/[country]/[locale]/(wholesale)/wholesale/cart/WholesaleCartView.tsx
@@ -5,9 +5,9 @@ import { ShoppingBag } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { QuantityPickerField } from "@/components/cart/QuantityPickerField";
 import { Button } from "@/components/ui/button";
 import { ProductImage } from "@/components/ui/product-image";
-import { QuantityPicker } from "@/components/ui/quantity-picker";
 import { useCart } from "@/contexts/CartContext";
 import { extractBasePath } from "@/lib/utils/path";
 import { WHOLESALE_MIN_QUANTITY } from "@/lib/wholesale";
@@ -120,12 +120,11 @@ export function WholesaleCartView() {
                 </div>
 
                 <div className="flex flex-col items-end gap-2">
-                  <QuantityPicker
+                  <QuantityPickerField
                     quantity={item.quantity}
-                    onDecrement={() =>
-                      updateItem(item.id, Math.max(1, item.quantity - 1))
+                    onQuantityChange={(quantity) =>
+                      updateItem(item.id, quantity)
                     }
-                    onIncrement={() => updateItem(item.id, item.quantity + 1)}
                   />
                   <Button
                     variant="destructive"

--- a/src/components/cart/CartDrawer.tsx
+++ b/src/components/cart/CartDrawer.tsx
@@ -6,9 +6,9 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
+import { QuantityPickerField } from "@/components/cart/QuantityPickerField";
 import { Button } from "@/components/ui/button";
 import { ProductImage } from "@/components/ui/product-image";
-import { QuantityPicker } from "@/components/ui/quantity-picker";
 import {
   Sheet,
   SheetContent,
@@ -194,13 +194,10 @@ export function CartDrawer() {
 
                       {/* Quantity & Price */}
                       <div className="mt-3 flex items-center justify-between">
-                        <QuantityPicker
+                        <QuantityPickerField
                           quantity={item.quantity}
-                          onDecrement={() =>
-                            updateItem(item.id, Math.max(1, item.quantity - 1))
-                          }
-                          onIncrement={() =>
-                            updateItem(item.id, item.quantity + 1)
+                          onQuantityChange={(quantity) =>
+                            updateItem(item.id, quantity)
                           }
                           disabled={updating}
                         />

--- a/src/components/cart/QuantityPickerField.tsx
+++ b/src/components/cart/QuantityPickerField.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type * as React from "react";
+import {
+  QuantityPicker,
+  type QuantityPickerProps,
+} from "@/components/ui/quantity-picker";
+
+type QuantityPickerFieldProps = Omit<
+  QuantityPickerProps,
+  "decrementLabel" | "incrementLabel" | "quantityLabel"
+>;
+
+// Owns the i18n binding for the label-agnostic ui/ primitive, so call sites
+// don't repeat the label wiring.
+export function QuantityPickerField(
+  props: QuantityPickerFieldProps,
+): React.JSX.Element {
+  const t = useTranslations("common");
+
+  return (
+    <QuantityPicker
+      decrementLabel={t("decreaseQuantity")}
+      incrementLabel={t("increaseQuantity")}
+      quantityLabel={t("quantity")}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/__tests__/quantity-picker.test.tsx
+++ b/src/components/ui/__tests__/quantity-picker.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { QuantityPicker } from "@/components/ui/quantity-picker";
+
+function setup(quantity = 20) {
+  const user = userEvent.setup();
+  const onQuantityChange = vi.fn();
+  render(
+    <QuantityPicker
+      quantity={quantity}
+      onQuantityChange={onQuantityChange}
+      decrementLabel="Decrease quantity"
+      incrementLabel="Increase quantity"
+      quantityLabel="Quantity"
+    />,
+  );
+  const input = screen.getByRole("textbox", { name: "Quantity" });
+  return { user, onQuantityChange, input };
+}
+
+describe("QuantityPicker", () => {
+  it("commits a typed quantity on blur", async () => {
+    const { user, onQuantityChange, input } = setup();
+
+    await user.click(input);
+    await user.keyboard("48");
+    await user.tab();
+
+    expect(onQuantityChange).toHaveBeenCalledTimes(1);
+    expect(onQuantityChange).toHaveBeenCalledWith(48);
+  });
+
+  it("commits a typed quantity on Enter", async () => {
+    const { user, onQuantityChange, input } = setup(1);
+
+    await user.click(input);
+    await user.keyboard("12{Enter}");
+
+    expect(onQuantityChange).toHaveBeenCalledWith(12);
+  });
+
+  it("ignores non-numeric characters while typing", async () => {
+    const { user, onQuantityChange, input } = setup(1);
+
+    await user.click(input);
+    await user.keyboard("1a.5{Enter}");
+
+    expect(onQuantityChange).toHaveBeenCalledWith(15);
+  });
+
+  it("reverts to the current quantity when the field is cleared", async () => {
+    const { user, onQuantityChange, input } = setup();
+
+    await user.click(input);
+    await user.keyboard("{Backspace}");
+    await user.tab();
+
+    expect(onQuantityChange).not.toHaveBeenCalled();
+    expect(input).toHaveValue("20");
+  });
+
+  it("clamps a typed quantity to the minimum", async () => {
+    const { user, onQuantityChange, input } = setup();
+
+    await user.click(input);
+    await user.keyboard("0{Enter}");
+
+    expect(onQuantityChange).toHaveBeenCalledWith(1);
+  });
+
+  it("does not call onQuantityChange when the typed value matches the quantity", async () => {
+    const { user, onQuantityChange, input } = setup();
+
+    await user.click(input);
+    await user.keyboard("20{Enter}");
+
+    expect(onQuantityChange).not.toHaveBeenCalled();
+  });
+
+  it("discards the draft on Escape", async () => {
+    const { user, onQuantityChange, input } = setup();
+
+    await user.click(input);
+    await user.keyboard("99{Escape}");
+    await user.tab();
+
+    expect(onQuantityChange).not.toHaveBeenCalled();
+    expect(input).toHaveValue("20");
+  });
+
+  it("increments and decrements around the current quantity", async () => {
+    const { user, onQuantityChange } = setup(5);
+
+    await user.click(screen.getByRole("button", { name: "Increase quantity" }));
+    expect(onQuantityChange).toHaveBeenLastCalledWith(6);
+
+    await user.click(screen.getByRole("button", { name: "Decrease quantity" }));
+    expect(onQuantityChange).toHaveBeenLastCalledWith(4);
+  });
+
+  it("disables the decrement button at the minimum quantity", () => {
+    setup(1);
+
+    expect(
+      screen.getByRole("button", { name: "Decrease quantity" }),
+    ).toBeDisabled();
+  });
+});

--- a/src/components/ui/quantity-picker.tsx
+++ b/src/components/ui/quantity-picker.tsx
@@ -1,52 +1,92 @@
 "use client";
 
 import { Minus, Plus } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 import { Button } from "./button";
 
-interface QuantityPickerProps {
+export interface QuantityPickerProps {
   quantity: number;
-  onDecrement: () => void;
-  onIncrement: () => void;
+  onQuantityChange: (quantity: number) => void;
+  decrementLabel: string;
+  incrementLabel: string;
+  quantityLabel: string;
   disabled?: boolean;
   size?: "sm" | "lg";
 }
 
 export function QuantityPicker({
   quantity,
-  onDecrement,
-  onIncrement,
+  onQuantityChange,
+  decrementLabel,
+  incrementLabel,
+  quantityLabel,
   disabled = false,
   size = "sm",
 }: QuantityPickerProps): React.JSX.Element {
+  // Holds the raw text while the user is typing; null means "not editing",
+  // so the displayed value tracks the quantity prop between edits without
+  // needing an effect to sync them.
+  const [draft, setDraft] = React.useState<string | null>(null);
+
+  const commitDraft = () => {
+    if (draft === null) return;
+    setDraft(null);
+    const parsed = Number.parseInt(draft, 10);
+    if (Number.isNaN(parsed)) return;
+    const next = Math.max(1, parsed);
+    if (next !== quantity) {
+      onQuantityChange(next);
+    }
+  };
+
   const buttonSize = size === "lg" ? "icon-lg" : "icon";
-  const spanClass =
+  const inputClass =
     size === "lg"
-      ? "px-4 font-medium min-w-[3rem] text-center tabular-nums"
-      : "px-3 py-2 text-sm font-medium min-w-[2rem] text-center tabular-nums";
+      ? "w-12 bg-transparent text-center font-medium tabular-nums outline-none disabled:opacity-50"
+      : "w-10 bg-transparent py-2 text-center text-sm font-medium tabular-nums outline-none disabled:opacity-50";
 
   return (
-    <div className="flex items-center border border-gray-300 rounded-lg px-0.5">
+    <div className="flex items-center border border-gray-300 rounded-lg px-0.5 focus-within:border-gray-500">
       <Button
         type="button"
         variant="ghost"
         size={buttonSize}
         className="rounded-md disabled:opacity-30"
         disabled={disabled || quantity <= 1}
-        onClick={onDecrement}
-        aria-label="Decrease quantity"
+        onClick={() => onQuantityChange(Math.max(1, quantity - 1))}
+        aria-label={decrementLabel}
       >
         <Minus className="w-3 h-3" />
       </Button>
-      <span className={spanClass}>{quantity}</span>
+      <input
+        type="text"
+        inputMode="numeric"
+        pattern="[0-9]*"
+        autoComplete="off"
+        value={draft ?? String(quantity)}
+        disabled={disabled}
+        aria-label={quantityLabel}
+        className={inputClass}
+        onChange={(e) => setDraft(e.target.value.replace(/\D/g, ""))}
+        onFocus={(e) => e.target.select()}
+        onBlur={commitDraft}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            e.currentTarget.blur();
+          } else if (e.key === "Escape") {
+            setDraft(null);
+          }
+        }}
+      />
       <Button
         type="button"
         variant="ghost"
         size={buttonSize}
         className="rounded-md disabled:opacity-30"
         disabled={disabled}
-        onClick={onIncrement}
-        aria-label="Increase quantity"
+        onClick={() => onQuantityChange(quantity + 1)}
+        aria-label={incrementLabel}
       >
         <Plus className="w-3 h-3" />
       </Button>


### PR DESCRIPTION
## Summary

Refactored the `QuantityPicker` component from a button-only interface to support direct text input, enabling users to type quantities directly. Created a new `QuantityPickerField` wrapper component to handle i18n bindings, reducing duplication across cart pages.

## Key Changes

- **QuantityPicker component redesign:**
  - Replaced static `<span>` display with an editable `<input>` field
  - Changed API from separate `onDecrement`/`onIncrement` callbacks to a single `onQuantityChange(quantity)` callback
  - Added required label props (`decrementLabel`, `incrementLabel`, `quantityLabel`) for accessibility
  - Implemented draft state management to handle user input without affecting the displayed quantity until committed
  - Added keyboard support: Enter to commit, Escape to discard, Backspace to clear
  - Filters non-numeric characters during input
  - Clamps values to minimum of 1
  - Only calls `onQuantityChange` when the value actually changes
  - Added focus-within border styling for better visual feedback

- **New QuantityPickerField component:**
  - Wrapper component that owns i18n bindings for the label-agnostic UI primitive
  - Eliminates repeated label wiring across call sites
  - Accepts the same props as QuantityPicker minus the label strings

- **Updated call sites:**
  - CartDrawer, cart page, wholesale cart, and ProductDetails now use `QuantityPickerField`
  - Simplified callback logic: `onQuantityChange(quantity)` instead of separate increment/decrement handlers

- **i18n updates:**
  - Moved quantity-related labels from cart-specific sections to `common` namespace (en, de, es, fr, pl)
  - Ensures consistent terminology across all uses of the component

## Implementation Details

- Uses a `draft` state (string | null) to track raw user input without affecting the displayed quantity
- `null` draft means "not editing", so the displayed value automatically tracks the `quantity` prop
- Input filtering via `replace(/\D/g, "")` removes non-numeric characters in real-time
- Commit logic validates parsed integer, clamps to minimum 1, and only triggers callback if value changed
- Maintains accessibility with proper `aria-label` attributes and semantic input attributes (`inputMode="numeric"`, `pattern="[0-9]*"`)

## Testing

Added comprehensive test suite covering:
- Committing typed quantities on blur and Enter
- Filtering non-numeric input
- Reverting cleared fields
- Clamping to minimum value
- Skipping callback when value unchanged
- Discarding draft on Escape
- Increment/decrement button behavior
- Disabling decrement at minimum quantity

https://claude.ai/code/session_01Prz2EBmiAFYJ7JjwALY22Y