### PR TITLE
Upgrades @spree/sdk to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@next/third-parties": "^16.1.6",
     "@paypal/react-paypal-js": "^9.1.1",
     "@sentry/nextjs": "^10.38.0",
-    "@spree/sdk": "^1.2.0",
+    "@spree/sdk": "^1.2.1",
     "@stripe/react-stripe-js": "^5.6.0",
     "@stripe/stripe-js": "^8.7.0",
     "@swc/helpers": "^0.5.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^10.38.0
         version: 10.54.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@20.19.41)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.107.2(esbuild@0.28.1))
       '@spree/sdk':
-        specifier: ^1.2.0
-        version: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^1.2.1
+        version: 1.2.1(typescript@5.9.3)(zod@3.25.76)
       '@stripe/react-stripe-js':
         specifier: ^5.6.0
         version: 5.6.1(@stripe/stripe-js@8.11.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2207,8 +2207,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@spree/sdk@1.2.0':
-    resolution: {integrity: sha512-ObHmFLLee3JVWSzTTadG0L646TwEW1A1R73nnLoTIzAW6Xim6sq3yCUbNmtLZaxIBDAOr+b+mKTvfkZWro0x1A==}
+  '@spree/sdk@1.2.1':
+    resolution: {integrity: sha512-SetAz9PIIAGBaJmpTwbc9hjnscZ17pVLmyC9C6YdnRZEDRtbad0wral6NLfBZa2YPvxKAaPWLdU0gAdgVaAm2Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       typescript: '>=4.7.0'
@@ -6750,7 +6750,7 @@ snapshots:
       execa: 9.6.1
       picocolors: 1.1.1
 
-  '@spree/sdk@1.2.0(typescript@5.9.3)(zod@3.25.76)':
+  '@spree/sdk@1.2.1(typescript@5.9.3)(zod@3.25.76)':
     optionalDependencies:
       typescript: 5.9.3
       zod: 3.25.76

--- a/src/components/products/filters/SortDropdownContent.tsx
+++ b/src/components/products/filters/SortDropdownContent.tsx
@@ -5,10 +5,10 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
 } from "@/components/ui/dropdown-menu";
-import { getSortLabel } from "@/lib/utils/filters";
+import { getSortOptionLabel } from "@/lib/utils/filters";
 
 interface SortDropdownContentProps {
-  sortOptions: { id: string }[];
+  sortOptions: { id: string; label?: string }[];
   activeSortBy?: string;
   onSortChange: (sortBy: string) => void;
 }
@@ -24,7 +24,7 @@ export function SortDropdownContent({
     <DropdownMenuRadioGroup value={activeSortBy} onValueChange={onSortChange}>
       {sortOptions.map((option) => (
         <DropdownMenuRadioItem key={option.id} value={option.id}>
-          {getSortLabel(option.id, t)}
+          {getSortOptionLabel(option, t)}
         </DropdownMenuRadioItem>
       ))}
     </DropdownMenuRadioGroup>

--- a/src/lib/utils/filters.ts
+++ b/src/lib/utils/filters.ts
@@ -67,6 +67,14 @@ export function getSortLabel(key: string, t?: (key: string) => string): string {
   return SORT_FALLBACK[normalized] || key;
 }
 
+export function getSortOptionLabel(
+  option: { id: string; label?: string },
+  t?: (key: string) => string,
+): string {
+  if (option.label) return option.label;
+  return getSortLabel(option.id, t);
+}
+
 /** Maps availability API values to translation message keys in the "products" namespace. */
 const AVAILABILITY_KEY_TO_MESSAGE: Record<string, string> = {
   in_stock: "inStock",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved product sorting controls to display custom sort-option labels when available.
  - Added a localized fallback for sorting options without custom labels.

- **Bug Fixes**
  - Improved consistency between available sorting options and the labels shown in the sorting menu.

- **Chores**
  - Updated the commerce SDK to the latest compatible patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->